### PR TITLE
Refactoring: プロジェクト名をlaravel-spectrumに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Laravel Prism
+# Laravel Spectrum
 
-[![Tests](https://github.com/wadakatu/laravel-prism/workflows/Tests/badge.svg)](https://github.com/wadakatu/laravel-prism/actions)
-[![Code Coverage](https://codecov.io/gh/wadakatu/laravel-prism/branch/main/graph/badge.svg)](https://codecov.io/gh/wadakatu/laravel-prism)
-[![Latest Stable Version](https://poser.pugx.org/wadakatu/laravel-prism/v)](https://packagist.org/packages/wadakatu/laravel-prism)
-[![Total Downloads](https://poser.pugx.org/wadakatu/laravel-prism/downloads)](https://packagist.org/packages/wadakatu/laravel-prism)
-[![License](https://poser.pugx.org/wadakatu/laravel-prism/license)](https://packagist.org/packages/wadakatu/laravel-prism)
-[![PHP Version Require](https://poser.pugx.org/wadakatu/laravel-prism/require/php)](https://packagist.org/packages/wadakatu/laravel-prism)
+[![Tests](https://github.com/wadakatu/laravel-spectrum/workflows/Tests/badge.svg)](https://github.com/wadakatu/laravel-spectrum/actions)
+[![Code Coverage](https://codecov.io/gh/wadakatu/laravel-spectrum/branch/main/graph/badge.svg)](https://codecov.io/gh/wadakatu/laravel-spectrum)
+[![Latest Stable Version](https://poser.pugx.org/wadakatu/laravel-spectrum/v)](https://packagist.org/packages/wadakatu/laravel-spectrum)
+[![Total Downloads](https://poser.pugx.org/wadakatu/laravel-spectrum/downloads)](https://packagist.org/packages/wadakatu/laravel-spectrum)
+[![License](https://poser.pugx.org/wadakatu/laravel-spectrum/license)](https://packagist.org/packages/wadakatu/laravel-spectrum)
+[![PHP Version Require](https://poser.pugx.org/wadakatu/laravel-spectrum/require/php)](https://packagist.org/packages/wadakatu/laravel-spectrum)
 
 > 🎯 **Zero-annotation API documentation generator for Laravel & Lumen**
 > 
@@ -68,13 +68,13 @@ Automatically detects and documents your API routes without any annotations or c
 
 ```bash
 # Generate your API documentation instantly
-php artisan prism:generate
+php artisan spectrum:generate
 
 # Watch mode for real-time updates
-php artisan prism:watch
+php artisan spectrum:watch
 ```
 
-![Laravel Prism Demo](https://user-images.githubusercontent.com/your-demo.gif)
+![Laravel Spectrum Demo](https://user-images.githubusercontent.com/your-demo.gif)
 
 ## 🔧 Requirements
 
@@ -85,7 +85,7 @@ php artisan prism:watch
 ## 📦 Installation
 
 ```bash
-composer require wadakatu/laravel-prism
+composer require wadakatu/laravel-spectrum
 ```
 
 That's it! No configuration needed to get started.
@@ -96,20 +96,20 @@ That's it! No configuration needed to get started.
 
 ```bash
 # Generate OpenAPI documentation
-php artisan prism:generate
+php artisan spectrum:generate
 
 # Generate in YAML format
-php artisan prism:generate --format=yaml
+php artisan spectrum:generate --format=yaml
 
 # Custom output path
-php artisan prism:generate --output=public/api-docs.json
+php artisan spectrum:generate --output=public/api-docs.json
 ```
 
 ### 2. Real-time Preview (Development)
 
 ```bash
 # Start the watcher with live reload
-php artisan prism:watch
+php artisan spectrum:watch
 
 # Visit http://localhost:8080 to see your documentation
 ```
@@ -252,13 +252,13 @@ Route::middleware('auth.apikey')->group(function () {
 Publish the configuration file for advanced customization:
 
 ```bash
-php artisan vendor:publish --tag=prism-config
+php artisan vendor:publish --tag=spectrum-config
 ```
 
 ### Configuration Options
 
 ```php
-// config/prism.php
+// config/spectrum.php
 return [
     // API Information
     'title' => env('APP_NAME', 'Laravel API'),
@@ -308,7 +308,7 @@ return [
     
     // Cache Configuration
     'cache' => [
-        'enabled' => env('PRISM_CACHE_ENABLED', true),
+        'enabled' => env('SPECTRUM_CACHE_ENABLED', true),
         'ttl' => 3600, // 1 hour
     ],
     
@@ -326,7 +326,7 @@ return [
 ### Custom Type Mappings
 
 ```php
-// config/prism.php
+// config/spectrum.php
 'type_mappings' => [
     'json' => ['type' => 'object'],
     'uuid' => ['type' => 'string', 'format' => 'uuid'],
@@ -398,7 +398,7 @@ class Handler extends ExceptionHandler
 php artisan route:list --path=api
 
 # Clear cache
-php artisan prism:clear-cache
+php artisan spectrum:clear-cache
 ```
 
 **Q: FormRequest validation rules not detected**
@@ -420,8 +420,8 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 ```bash
 # Setup development environment
-git clone https://github.com/wadakatu/laravel-prism.git
-cd laravel-prism
+git clone https://github.com/wadakatu/laravel-spectrum.git
+cd laravel-spectrum
 composer install
 
 # Run tests
@@ -443,5 +443,5 @@ The MIT License (MIT). Please see [License File](LICENSE.md) for more informatio
 <p align="center">
   Made with ❤️ by Wadakatu
   <br>
-  <a href="https://github.com/wadakatu/laravel-prism">Star ⭐ this repo</a> if you find it helpful!
+  <a href="https://github.com/wadakatu/laravel-spectrum">Star ⭐ this repo</a> if you find it helpful!
 </p>

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -1,0 +1,229 @@
+<svg viewBox="0 0 1200 300" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .pixel { shape-rendering: crispEdges; }
+      .glow-text { 
+        font-family: 'Courier New', monospace; 
+        font-weight: bold;
+        letter-spacing: 2px;
+      }
+    </style>
+    
+    <!-- Arcade glow effects -->
+    <filter id="neonGlow">
+      <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow">
+      <feGaussianBlur stdDeviation="5" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- CRT scanlines -->
+    <pattern id="scanlines" patternUnits="userSpaceOnUse" width="1200" height="3">
+      <line x1="0" y1="0" x2="1200" y2="0" stroke="#000000" stroke-width="1" opacity="0.15"/>
+    </pattern>
+    
+    <!-- Gradient effects -->
+    <linearGradient id="retroGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#FF1493;stop-opacity:1" />
+      <stop offset="25%" style="stop-color:#00FFFF;stop-opacity:1" />
+      <stop offset="50%" style="stop-color:#FFFF00;stop-opacity:1" />
+      <stop offset="75%" style="stop-color:#00FF00;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#FF1493;stop-opacity:1" />
+    </linearGradient>
+    
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#0A001A;stop-opacity:1" />
+      <stop offset="50%" style="stop-color:#1A0033;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#0A001A;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  
+  <!-- Background -->
+  <rect width="1200" height="300" fill="url(#bgGradient)" class="pixel"/>
+  
+  <!-- Animated starfield -->
+  <g class="pixel">
+    <!-- Static stars -->
+    <rect x="100" y="30" width="2" height="2" fill="#FFFFFF" opacity="0.4"/>
+    <rect x="250" y="50" width="2" height="2" fill="#FFFFFF" opacity="0.6"/>
+    <rect x="400" y="40" width="2" height="2" fill="#FFFFFF" opacity="0.5"/>
+    <rect x="550" y="60" width="2" height="2" fill="#FFFFFF" opacity="0.4"/>
+    <rect x="700" y="35" width="2" height="2" fill="#FFFFFF" opacity="0.6"/>
+    <rect x="850" y="55" width="2" height="2" fill="#FFFFFF" opacity="0.5"/>
+    <rect x="1000" y="45" width="2" height="2" fill="#FFFFFF" opacity="0.4"/>
+    <rect x="1100" y="30" width="2" height="2" fill="#FFFFFF" opacity="0.5"/>
+    
+    <!-- Animated stars -->
+    <circle cx="150" cy="250" r="1" fill="#FFFFFF">
+      <animate attributeName="opacity" values="0;0.8;0" dur="2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="950" cy="270" r="1" fill="#FFFFFF">
+      <animate attributeName="opacity" values="0;0.8;0" dur="2.5s" begin="0.5s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="500" cy="260" r="1" fill="#FFFFFF">
+      <animate attributeName="opacity" values="0;0.8;0" dur="2s" begin="1s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  
+  <!-- Neon border frame -->
+  <rect x="20" y="20" width="1160" height="260" fill="none" stroke="#00FFFF" stroke-width="3" class="pixel" opacity="0.6" filter="url(#neonGlow)"/>
+  <rect x="30" y="30" width="1140" height="240" fill="none" stroke="#FF00FF" stroke-width="1" class="pixel" opacity="0.4"/>
+  
+  <!-- Grid pattern -->
+  <g opacity="0.1">
+    <pattern id="grid" patternUnits="userSpaceOnUse" width="20" height="20">
+      <rect x="0" y="0" width="20" height="20" fill="none" stroke="#00FFFF" stroke-width="0.5"/>
+    </pattern>
+    <rect x="40" y="40" width="1120" height="220" fill="url(#grid)" class="pixel"/>
+  </g>
+  
+  <!-- Left side: Animated Prism -->
+  <g transform="translate(200, 150)" class="pixel">
+    <!-- Outer glow animation -->
+    <g opacity="0.3" filter="url(#strongGlow)">
+      <rect x="-70" y="-70" width="140" height="140" fill="#FFFF00" opacity="0.3">
+        <animate attributeName="width" values="140;160;140" dur="3s" repeatCount="indefinite"/>
+        <animate attributeName="height" values="140;160;140" dur="3s" repeatCount="indefinite"/>
+        <animate attributeName="x" values="-70;-80;-70" dur="3s" repeatCount="indefinite"/>
+        <animate attributeName="y" values="-70;-80;-70" dur="3s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    
+    <!-- Main prism with scale animation -->
+    <g transform="scale(2.8)">
+      <animateTransform attributeName="transform" type="scale" values="2.8;3;2.8" dur="4s" repeatCount="indefinite"/>
+      
+      <!-- Top shine -->
+      <rect x="-4" y="-20" width="8" height="4" fill="#FFFFFF"/>
+      <rect x="-2" y="-18" width="4" height="2" fill="#FFFFFF" opacity="0.9">
+        <animate attributeName="opacity" values="0.9;1;0.9" dur="1s" repeatCount="indefinite"/>
+      </rect>
+      
+      <!-- Prism body with rainbow colors -->
+      <rect x="-8" y="-16" width="16" height="4" fill="#FF1493"/>
+      <rect x="-12" y="-12" width="24" height="4" fill="#FF69B4"/>
+      <rect x="-16" y="-8" width="32" height="4" fill="#00FFFF"/>
+      <rect x="-16" y="-4" width="32" height="4" fill="#00CED1"/>
+      <rect x="-12" y="0" width="24" height="4" fill="#40E0D0"/>
+      <rect x="-8" y="4" width="16" height="4" fill="#7FFF00"/>
+      <rect x="-4" y="8" width="8" height="4" fill="#ADFF2F"/>
+      
+      <!-- Light beams -->
+      <g filter="url(#neonGlow)">
+        <rect x="-45" y="-4" width="25" height="2" fill="#FFFF00" opacity="0.8">
+          <animate attributeName="x" values="-45;-40;-45" dur="1.5s" repeatCount="indefinite"/>
+        </rect>
+        
+        <!-- Rainbow burst -->
+        <g opacity="0.9">
+          <rect x="16" y="-12" width="20" height="2" fill="#FF0000"/>
+          <rect x="16" y="-8" width="22" height="2" fill="#FFA500"/>
+          <rect x="16" y="-4" width="24" height="2" fill="#FFFF00"/>
+          <rect x="16" y="0" width="22" height="2" fill="#00FF00"/>
+          <rect x="16" y="4" width="20" height="2" fill="#0000FF"/>
+        </g>
+      </g>
+    </g>
+    
+    <!-- Orbiting pixels -->
+    <g class="pixel">
+      <rect x="-75" y="-32" width="5" height="5" fill="#FF00FF">
+        <animateTransform attributeName="transform" type="rotate" from="0 0 0" to="360 0 0" dur="5s" repeatCount="indefinite"/>
+      </rect>
+      <rect x="75" y="32" width="5" height="5" fill="#00FFFF">
+        <animateTransform attributeName="transform" type="rotate" from="0 0 0" to="-360 0 0" dur="7s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+  </g>
+  
+  <!-- Main title: LARAVEL SPECTRUM -->
+  <g class="pixel">
+    <!-- Shadow -->
+    <text x="702" y="122" text-anchor="middle" class="glow-text" font-size="55" fill="#000000" opacity="0.5">LARAVEL SPECTRUM</text>
+    
+    <!-- Main text with gradient -->
+    <text x="700" y="120" text-anchor="middle" class="glow-text" font-size="55" fill="url(#retroGradient)" filter="url(#strongGlow)">LARAVEL SPECTRUM</text>
+    
+    <!-- Highlight overlay -->
+    <text x="700" y="120" text-anchor="middle" class="glow-text" font-size="55" fill="#FFFFFF" opacity="0.2">LARAVEL SPECTRUM</text>
+  </g>
+  
+  <!-- Subtitle -->
+  <g class="pixel">
+    <text x="700" y="165" text-anchor="middle" font-family="monospace" font-size="24" fill="#00FFFF" filter="url(#neonGlow)">
+      ZERO-ANNOTATION API DOCUMENTATION
+    </text>
+    <text x="700" y="195" text-anchor="middle" font-family="monospace" font-size="18" fill="#FFFF00" opacity="0.8">
+      Auto-Generate OpenAPI Docs for Laravel
+    </text>
+  </g>
+  
+  <!-- Arcade UI elements -->
+  <g class="pixel">
+    <!-- Version badge -->
+    <rect x="40" y="225" width="120" height="40" fill="#000000" stroke="#00FF00" stroke-width="3" opacity="0.8"/>
+    <text x="100" y="250" text-anchor="middle" font-family="monospace" font-size="16" fill="#00FF00">
+      v1.0.0
+    </text>
+    
+    <!-- Status indicator -->
+    <rect x="1040" y="225" width="120" height="40" fill="#000000" stroke="#FFFF00" stroke-width="3" opacity="0.8"/>
+    <text x="1100" y="250" text-anchor="middle" font-family="monospace" font-size="16" fill="#FFFF00">
+      READY
+    </text>
+    
+    <!-- Power level bars -->
+    <g transform="translate(650, 240)">
+      <rect x="0" y="0" width="8" height="20" fill="#00FF00" opacity="0.8">
+        <animate attributeName="height" values="20;15;20" dur="0.5s" repeatCount="indefinite"/>
+      </rect>
+      <rect x="12" y="0" width="8" height="20" fill="#00FF00" opacity="0.8">
+        <animate attributeName="height" values="20;18;20" dur="0.5s" begin="0.1s" repeatCount="indefinite"/>
+      </rect>
+      <rect x="24" y="0" width="8" height="20" fill="#FFFF00" opacity="0.8">
+        <animate attributeName="height" values="20;12;20" dur="0.5s" begin="0.2s" repeatCount="indefinite"/>
+      </rect>
+      <rect x="36" y="0" width="8" height="20" fill="#FFFF00" opacity="0.8">
+        <animate attributeName="height" values="20;16;20" dur="0.5s" begin="0.3s" repeatCount="indefinite"/>
+      </rect>
+      <rect x="48" y="0" width="8" height="20" fill="#FF0000" opacity="0.8">
+        <animate attributeName="height" values="20;14;20" dur="0.5s" begin="0.4s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+  </g>
+  
+  <!-- Corner decorations -->
+  <g class="pixel">
+    <!-- Top left -->
+    <rect x="40" y="40" width="20" height="4" fill="#FF00FF" opacity="0.6"/>
+    <rect x="40" y="40" width="4" height="20" fill="#FF00FF" opacity="0.6"/>
+    
+    <!-- Top right -->
+    <rect x="1140" y="40" width="20" height="4" fill="#00FFFF" opacity="0.6"/>
+    <rect x="1156" y="40" width="4" height="20" fill="#00FFFF" opacity="0.6"/>
+    
+    <!-- Bottom left -->
+    <rect x="40" y="256" width="20" height="4" fill="#00FFFF" opacity="0.6"/>
+    <rect x="40" y="240" width="4" height="20" fill="#00FFFF" opacity="0.6"/>
+    
+    <!-- Bottom right -->
+    <rect x="1140" y="256" width="20" height="4" fill="#FF00FF" opacity="0.6"/>
+    <rect x="1156" y="240" width="4" height="20" fill="#FF00FF" opacity="0.6"/>
+  </g>
+  
+  <!-- CRT effect overlay -->
+  <rect width="1200" height="300" fill="url(#scanlines)" opacity="0.2" class="pixel"/>
+  
+  <!-- Screen glare -->
+  <ellipse cx="250" cy="80" rx="150" ry="50" fill="#FFFFFF" opacity="0.05" transform="rotate(-30 250 80)"/>
+</svg>

--- a/assets/icon.svg
+++ b/assets/icon.svg
@@ -1,0 +1,129 @@
+<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .pixel { shape-rendering: crispEdges; }
+    </style>
+    
+    <!-- Glow effect -->
+    <filter id="pixelGlow">
+      <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Strong glow for important elements -->
+    <filter id="strongGlow">
+      <feGaussianBlur stdDeviation="4" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  
+  <!-- Background -->
+  <rect width="200" height="200" fill="#0A001A" rx="20" class="pixel"/>
+  
+  <!-- Inner frame -->
+  <rect x="10" y="10" width="180" height="180" fill="#1A0033" rx="16" class="pixel"/>
+  <rect x="15" y="15" width="170" height="170" fill="none" stroke="#00FFFF" stroke-width="2" rx="14" class="pixel" opacity="0.6" filter="url(#pixelGlow)"/>
+  
+  <!-- Main pixelated prism (larger and centered) -->
+  <g transform="translate(100, 105)" class="pixel" filter="url(#strongGlow)">
+    <!-- Top highlight (larger) -->
+    <rect x="-10" y="-60" width="20" height="10" fill="#FFFFFF"/>
+    <rect x="-5" y="-55" width="10" height="5" fill="#FFFFFF" opacity="0.9"/>
+    
+    <!-- Main prism body (scaled up) -->
+    <!-- Row 1 -->
+    <rect x="-20" y="-48" width="10" height="10" fill="#FF1493"/>
+    <rect x="-10" y="-48" width="20" height="10" fill="#FF1493"/>
+    <rect x="10" y="-48" width="10" height="10" fill="#FF1493"/>
+    
+    <!-- Row 2 -->
+    <rect x="-30" y="-38" width="10" height="10" fill="#FF69B4"/>
+    <rect x="-20" y="-38" width="40" height="10" fill="#FF69B4"/>
+    <rect x="20" y="-38" width="10" height="10" fill="#FF69B4"/>
+    
+    <!-- Row 3 -->
+    <rect x="-40" y="-28" width="80" height="10" fill="#00FFFF"/>
+    
+    <!-- Row 4 -->
+    <rect x="-40" y="-18" width="80" height="10" fill="#00CED1"/>
+    
+    <!-- Row 5 -->
+    <rect x="-40" y="-8" width="80" height="10" fill="#40E0D0"/>
+    
+    <!-- Row 6 -->
+    <rect x="-30" y="2" width="60" height="10" fill="#7FFF00"/>
+    
+    <!-- Row 7 -->
+    <rect x="-20" y="12" width="40" height="10" fill="#ADFF2F"/>
+    
+    <!-- Row 8 -->
+    <rect x="-10" y="22" width="20" height="10" fill="#32CD32"/>
+    
+    <!-- Light beam pixels (larger) -->
+    <rect x="-70" y="-18" width="24" height="6" fill="#FFFF00" opacity="0.8"/>
+    <rect x="-66" y="-12" width="16" height="6" fill="#FFFF00" opacity="0.6"/>
+    
+    <!-- Rainbow burst pixels (larger) -->
+    <rect x="46" y="-28" width="20" height="6" fill="#FF0000" opacity="0.9"/>
+    <rect x="50" y="-22" width="16" height="6" fill="#FF0000" opacity="0.7"/>
+    
+    <rect x="46" y="-18" width="24" height="6" fill="#FFA500" opacity="0.9"/>
+    <rect x="54" y="-12" width="16" height="6" fill="#FFA500" opacity="0.7"/>
+    
+    <rect x="46" y="-8" width="28" height="6" fill="#FFFF00" opacity="0.9"/>
+    
+    <rect x="46" y="2" width="24" height="6" fill="#00FF00" opacity="0.9"/>
+    <rect x="54" y="8" width="16" height="6" fill="#00FF00" opacity="0.7"/>
+    
+    <rect x="46" y="12" width="20" height="6" fill="#0000FF" opacity="0.9"/>
+    <rect x="50" y="18" width="16" height="6" fill="#0000FF" opacity="0.7"/>
+  </g>
+  
+  <!-- Corner decorations -->
+  <g class="pixel">
+    <!-- Top-left -->
+    <rect x="20" y="20" width="4" height="4" fill="#FF00FF" opacity="0.8"/>
+    <rect x="24" y="20" width="4" height="4" fill="#FF00FF" opacity="0.6"/>
+    <rect x="20" y="24" width="4" height="4" fill="#FF00FF" opacity="0.6"/>
+    
+    <!-- Top-right -->
+    <rect x="176" y="20" width="4" height="4" fill="#00FFFF" opacity="0.8"/>
+    <rect x="172" y="20" width="4" height="4" fill="#00FFFF" opacity="0.6"/>
+    <rect x="176" y="24" width="4" height="4" fill="#00FFFF" opacity="0.6"/>
+    
+    <!-- Bottom-left -->
+    <rect x="20" y="176" width="4" height="4" fill="#00FFFF" opacity="0.8"/>
+    <rect x="24" y="176" width="4" height="4" fill="#00FFFF" opacity="0.6"/>
+    <rect x="20" y="172" width="4" height="4" fill="#00FFFF" opacity="0.6"/>
+    
+    <!-- Bottom-right -->
+    <rect x="176" y="176" width="4" height="4" fill="#FF00FF" opacity="0.8"/>
+    <rect x="172" y="176" width="4" height="4" fill="#FF00FF" opacity="0.6"/>
+    <rect x="176" y="172" width="4" height="4" fill="#FF00FF" opacity="0.6"/>
+  </g>
+  
+  <!-- Floating pixels animation -->
+  <g class="pixel">
+    <rect x="30" y="40" width="2" height="2" fill="#FFFF00" opacity="0.5">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="170" y="50" width="2" height="2" fill="#00FFFF" opacity="0.5">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="2.5s" begin="0.5s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="160" width="2" height="2" fill="#FF00FF" opacity="0.5">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="2s" begin="1s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="160" y="150" width="2" height="2" fill="#00FF00" opacity="0.5">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="2.5s" begin="1.5s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  
+
+</svg>

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "wadakatu/laravel-prism",
+    "name": "wadakatu/laravel-spectrum",
     "description": "Zero-annotation API documentation generator for Laravel and Lumen",
     "keywords": [
         "laravel",
@@ -19,12 +19,12 @@
             "email": "wadakatukoyo330@gmail.com"
         }
     ],
-    "homepage": "https://github.com/wadakatu/laravel-prism",
+    "homepage": "https://github.com/wadakatu/laravel-spectrum",
     "support": {
-        "issues": "https://github.com/wadakatu/laravel-prism/issues",
-        "source": "https://github.com/wadakatu/laravel-prism",
-        "docs": "https://github.com/wadakatu/laravel-prism#readme",
-        "changelog": "https://github.com/wadakatu/laravel-prism/releases"
+        "issues": "https://github.com/wadakatu/laravel-spectrum/issues",
+        "source": "https://github.com/wadakatu/laravel-spectrum",
+        "docs": "https://github.com/wadakatu/laravel-spectrum#readme",
+        "changelog": "https://github.com/wadakatu/laravel-spectrum/releases"
     },
     "require": {
         "php": "^8.1",
@@ -43,12 +43,12 @@
     },
     "autoload": {
         "psr-4": {
-            "LaravelPrism\\": "src/"
+            "LaravelSpectrum\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "LaravelPrism\\Tests\\": "tests/",
+            "LaravelSpectrum\\Tests\\": "tests/",
             "Tests\\Unit\\Analyzers\\Fixtures\\": "tests/Unit/Analyzers/Fixtures/",
             "League\\Fractal\\": "tests/Fixtures/vendor/league/fractal/"
         }
@@ -73,7 +73,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "LaravelPrism\\PrismServiceProvider"
+                "LaravelSpectrum\\SpectrumServiceProvider"
             ]
         }
     },

--- a/config/spectrum.php
+++ b/config/spectrum.php
@@ -151,7 +151,7 @@ return [
         | The directory where cache files will be stored.
         |
         */
-        'directory' => storage_path('app/prism/cache'),
+        'directory' => storage_path('app/spectrum/cache'),
 
         /*
         |--------------------------------------------------------------------------

--- a/phpunit-legacy.xml
+++ b/phpunit-legacy.xml
@@ -13,7 +13,7 @@
          beStrictAboutOutputDuringTests="true"
 >
     <testsuites>
-        <testsuite name="Laravel Prism Test Suite">
+        <testsuite name="Laravel Spectrum Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,7 +18,7 @@
          verbose="true"
 >
     <testsuites>
-        <testsuite name="Laravel Prism Test Suite">
+        <testsuite name="Laravel Spectrum Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>

--- a/src/Analyzers/AST/Visitors/AnonymousClassFindingVisitor.php
+++ b/src/Analyzers/AST/Visitors/AnonymousClassFindingVisitor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Analyzers\AST\Visitors;
+namespace LaravelSpectrum\Analyzers\AST\Visitors;
 
 use PhpParser\Node;
 use PhpParser\NodeTraverser;

--- a/src/Analyzers/AST/Visitors/ArrayReturnExtractorVisitor.php
+++ b/src/Analyzers/AST/Visitors/ArrayReturnExtractorVisitor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Analyzers\AST\Visitors;
+namespace LaravelSpectrum\Analyzers\AST\Visitors;
 
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;

--- a/src/Analyzers/AST/Visitors/ClassFindingVisitor.php
+++ b/src/Analyzers/AST/Visitors/ClassFindingVisitor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Analyzers\AST\Visitors;
+namespace LaravelSpectrum\Analyzers\AST\Visitors;
 
 use PhpParser\Node;
 use PhpParser\NodeTraverser;

--- a/src/Analyzers/AST/Visitors/ConditionalRulesExtractorVisitor.php
+++ b/src/Analyzers/AST/Visitors/ConditionalRulesExtractorVisitor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Analyzers\AST\Visitors;
+namespace LaravelSpectrum\Analyzers\AST\Visitors;
 
 use PhpParser\Node;
 use PhpParser\NodeTraverser;

--- a/src/Analyzers/AST/Visitors/ResourceStructureVisitor.php
+++ b/src/Analyzers/AST/Visitors/ResourceStructureVisitor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Analyzers\AST\Visitors;
+namespace LaravelSpectrum\Analyzers\AST\Visitors;
 
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;

--- a/src/Analyzers/AST/Visitors/RulesExtractorVisitor.php
+++ b/src/Analyzers/AST/Visitors/RulesExtractorVisitor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Analyzers\AST\Visitors;
+namespace LaravelSpectrum\Analyzers\AST\Visitors;
 
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;

--- a/src/Analyzers/AuthenticationAnalyzer.php
+++ b/src/Analyzers/AuthenticationAnalyzer.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace LaravelPrism\Analyzers;
+namespace LaravelSpectrum\Analyzers;
 
-use LaravelPrism\Support\AuthenticationDetector;
+use LaravelSpectrum\Support\AuthenticationDetector;
 
 class AuthenticationAnalyzer
 {
@@ -65,7 +65,7 @@ class AuthenticationAnalyzer
      */
     public function loadCustomSchemes(): void
     {
-        $customSchemes = config('prism.authentication.custom_schemes', []);
+        $customSchemes = config('spectrum.authentication.custom_schemes', []);
 
         foreach ($customSchemes as $middleware => $scheme) {
             AuthenticationDetector::addCustomScheme($middleware, $scheme);
@@ -77,7 +77,7 @@ class AuthenticationAnalyzer
      */
     public function getGlobalAuthentication(): ?array
     {
-        $globalAuth = config('prism.authentication.global');
+        $globalAuth = config('spectrum.authentication.global');
 
         if (! $globalAuth || ! $globalAuth['enabled']) {
             return null;
@@ -94,7 +94,7 @@ class AuthenticationAnalyzer
      */
     public function getPatternBasedAuthentication(string $uri): ?array
     {
-        $patterns = config('prism.authentication.patterns', []);
+        $patterns = config('spectrum.authentication.patterns', []);
 
         foreach ($patterns as $pattern => $auth) {
             if (\Illuminate\Support\Str::is($pattern, $uri)) {

--- a/src/Analyzers/ControllerAnalyzer.php
+++ b/src/Analyzers/ControllerAnalyzer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Analyzers;
+namespace LaravelSpectrum\Analyzers;
 
 use Illuminate\Foundation\Http\FormRequest;
 use PhpParser\Node;

--- a/src/Analyzers/FormRequestAnalyzer.php
+++ b/src/Analyzers/FormRequestAnalyzer.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace LaravelPrism\Analyzers;
+namespace LaravelSpectrum\Analyzers;
 
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
-use LaravelPrism\Cache\DocumentationCache;
-use LaravelPrism\Support\TypeInference;
+use LaravelSpectrum\Cache\DocumentationCache;
+use LaravelSpectrum\Support\TypeInference;
 use PhpParser\Error;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;

--- a/src/Analyzers/FractalTransformerAnalyzer.php
+++ b/src/Analyzers/FractalTransformerAnalyzer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Analyzers;
+namespace LaravelSpectrum\Analyzers;
 
 use Illuminate\Support\Str;
 use PhpParser\Node;

--- a/src/Analyzers/InlineValidationAnalyzer.php
+++ b/src/Analyzers/InlineValidationAnalyzer.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace LaravelPrism\Analyzers;
+namespace LaravelSpectrum\Analyzers;
 
-use LaravelPrism\Support\TypeInference;
+use LaravelSpectrum\Support\TypeInference;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;

--- a/src/Analyzers/ResourceAnalyzer.php
+++ b/src/Analyzers/ResourceAnalyzer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace LaravelPrism\Analyzers;
+namespace LaravelSpectrum\Analyzers;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Facades\Log;
-use LaravelPrism\Cache\DocumentationCache;
+use LaravelSpectrum\Cache\DocumentationCache;
 use PhpParser\Error;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;

--- a/src/Analyzers/RouteAnalyzer.php
+++ b/src/Analyzers/RouteAnalyzer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace LaravelPrism\Analyzers;
+namespace LaravelSpectrum\Analyzers;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
-use LaravelPrism\Cache\DocumentationCache;
+use LaravelSpectrum\Cache\DocumentationCache;
 
 class RouteAnalyzer
 {
@@ -74,7 +74,7 @@ class RouteAnalyzer
     protected function isApiRoute($route): bool
     {
         $uri = $route->uri();
-        $configPatterns = config('prism.route_patterns', ['api/*']);
+        $configPatterns = config('spectrum.route_patterns', ['api/*']);
 
         foreach ($configPatterns as $pattern) {
             if (Str::is($pattern, $uri)) {

--- a/src/Cache/DocumentationCache.php
+++ b/src/Cache/DocumentationCache.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Cache;
+namespace LaravelSpectrum\Cache;
 
 use Illuminate\Support\Facades\File;
 
@@ -12,8 +12,8 @@ class DocumentationCache
 
     public function __construct()
     {
-        $this->cacheDir = config('prism.cache.directory', storage_path('app/prism/cache'));
-        $this->enabled = config('prism.cache.enabled', true);
+        $this->cacheDir = config('spectrum.cache.directory', storage_path('app/spectrum/cache'));
+        $this->enabled = config('spectrum.cache.enabled', true);
 
         if ($this->enabled) {
             File::ensureDirectoryExists($this->cacheDir);
@@ -103,7 +103,7 @@ class DocumentationCache
         ];
 
         // カスタムルートファイルも含める
-        $customRoutes = config('prism.route_files', []);
+        $customRoutes = config('spectrum.route_files', []);
         $routeFiles = array_merge($routeFiles, $customRoutes);
 
         $existingFiles = array_filter($routeFiles, 'file_exists');

--- a/src/Console/CacheCommand.php
+++ b/src/Console/CacheCommand.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace LaravelPrism\Console;
+namespace LaravelSpectrum\Console;
 
 use Illuminate\Console\Command;
-use LaravelPrism\Cache\DocumentationCache;
+use LaravelSpectrum\Cache\DocumentationCache;
 
 class CacheCommand extends Command
 {
-    protected $signature = 'prism:cache
+    protected $signature = 'spectrum:cache
                             {action : Action to perform (clear|stats|warm)}';
 
-    protected $description = 'Manage Laravel Prism cache';
+    protected $description = 'Manage Laravel Spectrum cache';
 
     private DocumentationCache $cache;
 
@@ -73,7 +73,7 @@ class CacheCommand extends Command
         // キャッシュをクリアしてから再生成
         $this->cache->clear();
 
-        $this->call('prism:generate', [
+        $this->call('spectrum:generate', [
             '--quiet' => true,
         ]);
 

--- a/src/Console/GenerateDocsCommand.php
+++ b/src/Console/GenerateDocsCommand.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace LaravelPrism\Console;
+namespace LaravelSpectrum\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
-use LaravelPrism\Analyzers\RouteAnalyzer;
-use LaravelPrism\Cache\DocumentationCache;
-use LaravelPrism\Generators\OpenApiGenerator;
+use LaravelSpectrum\Analyzers\RouteAnalyzer;
+use LaravelSpectrum\Cache\DocumentationCache;
+use LaravelSpectrum\Generators\OpenApiGenerator;
 
 class GenerateDocsCommand extends Command
 {
-    protected $signature = 'prism:generate 
+    protected $signature = 'spectrum:generate 
                             {--format=json : Output format (json|yaml)}
                             {--output= : Output file path}
                             {--no-cache : Disable cache}
@@ -44,7 +44,7 @@ class GenerateDocsCommand extends Command
         }
 
         if ($this->option('no-cache')) {
-            config(['prism.cache.enabled' => false]);
+            config(['spectrum.cache.enabled' => false]);
         }
 
         $startTime = microtime(true);
@@ -54,7 +54,7 @@ class GenerateDocsCommand extends Command
         $routes = $this->routeAnalyzer->analyze();
 
         if (empty($routes)) {
-            $this->warn('No API routes found. Make sure your routes match the patterns in config/prism.php');
+            $this->warn('No API routes found. Make sure your routes match the patterns in config/spectrum.php');
 
             return 1;
         }
@@ -95,7 +95,7 @@ class GenerateDocsCommand extends Command
     {
         $format = $this->option('format');
 
-        return storage_path("app/prism/openapi.{$format}");
+        return storage_path("app/spectrum/openapi.{$format}");
     }
 
     protected function formatOutput(array $openapi, string $format): string

--- a/src/Console/WatchCommand.php
+++ b/src/Console/WatchCommand.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace LaravelPrism\Console;
+namespace LaravelSpectrum\Console;
 
 use Illuminate\Console\Command;
-use LaravelPrism\Services\DocumentationCache;
-use LaravelPrism\Services\FileWatcher;
-use LaravelPrism\Services\LiveReloadServer;
+use LaravelSpectrum\Services\DocumentationCache;
+use LaravelSpectrum\Services\FileWatcher;
+use LaravelSpectrum\Services\LiveReloadServer;
 use Workerman\Worker;
 
 class WatchCommand extends Command
 {
-    protected $signature = 'prism:watch
+    protected $signature = 'spectrum:watch
                             {--port=8080 : Port for the preview server}
                             {--host=127.0.0.1 : Host for the preview server}
                             {--no-open : Don\'t open browser automatically}';
@@ -39,7 +39,7 @@ class WatchCommand extends Command
         $this->info('🚀 Starting Laravel Prism preview server...');
 
         // Initial generation
-        $this->call('prism:generate', ['--quiet' => true]);
+        $this->call('spectrum:generate', ['--quiet' => true]);
 
         // Open browser
         if (! $this->option('no-open')) {
@@ -76,7 +76,7 @@ class WatchCommand extends Command
 
         // Regenerate (incremental)
         $startTime = microtime(true);
-        $this->call('prism:generate', ['--quiet' => true]);
+        $this->call('spectrum:generate', ['--quiet' => true]);
         $duration = round(microtime(true) - $startTime, 2);
 
         $this->info("✅ Documentation updated in {$duration}s");
@@ -91,7 +91,7 @@ class WatchCommand extends Command
 
     private function getWatchPaths(): array
     {
-        return config('prism.watch.paths', [
+        return config('spectrum.watch.paths', [
             app_path('Http/Controllers'),
             app_path('Http/Requests'),
             app_path('Http/Resources'),

--- a/src/Generators/ErrorResponseGenerator.php
+++ b/src/Generators/ErrorResponseGenerator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Generators;
+namespace LaravelSpectrum\Generators;
 
 class ErrorResponseGenerator
 {

--- a/src/Generators/OpenApiGenerator.php
+++ b/src/Generators/OpenApiGenerator.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace LaravelPrism\Generators;
+namespace LaravelSpectrum\Generators;
 
 use Illuminate\Support\Str;
-use LaravelPrism\Analyzers\AuthenticationAnalyzer;
-use LaravelPrism\Analyzers\ControllerAnalyzer;
-use LaravelPrism\Analyzers\FormRequestAnalyzer;
-use LaravelPrism\Analyzers\InlineValidationAnalyzer;
-use LaravelPrism\Analyzers\ResourceAnalyzer;
+use LaravelSpectrum\Analyzers\AuthenticationAnalyzer;
+use LaravelSpectrum\Analyzers\ControllerAnalyzer;
+use LaravelSpectrum\Analyzers\FormRequestAnalyzer;
+use LaravelSpectrum\Analyzers\InlineValidationAnalyzer;
+use LaravelSpectrum\Analyzers\ResourceAnalyzer;
 
 class OpenApiGenerator
 {
@@ -61,9 +61,9 @@ class OpenApiGenerator
         $openapi = [
             'openapi' => '3.0.0',
             'info' => [
-                'title' => config('prism.title', config('app.name').' API'),
-                'version' => config('prism.version', '1.0.0'),
-                'description' => config('prism.description', ''),
+                'title' => config('spectrum.title', config('app.name').' API'),
+                'version' => config('spectrum.version', '1.0.0'),
+                'description' => config('spectrum.description', ''),
             ],
             'servers' => [
                 [

--- a/src/Generators/SchemaGenerator.php
+++ b/src/Generators/SchemaGenerator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Generators;
+namespace LaravelSpectrum\Generators;
 
 class SchemaGenerator
 {

--- a/src/Generators/SecuritySchemeGenerator.php
+++ b/src/Generators/SecuritySchemeGenerator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Generators;
+namespace LaravelSpectrum\Generators;
 
 class SecuritySchemeGenerator
 {

--- a/src/Generators/ValidationMessageGenerator.php
+++ b/src/Generators/ValidationMessageGenerator.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace LaravelPrism\Generators;
+namespace LaravelSpectrum\Generators;
 
 use Illuminate\Support\Str;
-use LaravelPrism\Support\ValidationRules;
+use LaravelSpectrum\Support\ValidationRules;
 
 class ValidationMessageGenerator
 {

--- a/src/Services/DocumentationCache.php
+++ b/src/Services/DocumentationCache.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace LaravelPrism\Services;
+namespace LaravelSpectrum\Services;
 
 use Illuminate\Support\Facades\Cache;
 
 class DocumentationCache
 {
-    private string $prefix = 'prism:';
+    private string $prefix = 'spectrum:';
 
     private int $ttl = 3600; // 1 hour
 
@@ -27,7 +27,7 @@ class DocumentationCache
 
     public function flush(): bool
     {
-        // Clear all prism cache entries
+        // Clear all spectrum cache entries
         return Cache::flush();
     }
 

--- a/src/Services/FileWatcher.php
+++ b/src/Services/FileWatcher.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Services;
+namespace LaravelSpectrum\Services;
 
 use Symfony\Component\Finder\Finder;
 use Workerman\Timer;

--- a/src/Services/LiveReloadServer.php
+++ b/src/Services/LiveReloadServer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Services;
+namespace LaravelSpectrum\Services;
 
 use Workerman\Connection\TcpConnection;
 use Workerman\Protocols\Http\Request;
@@ -45,7 +45,7 @@ class LiveReloadServer
                     'Content-Type' => 'text/html; charset=utf-8',
                 ], $this->getSwaggerUIHtml()));
             } elseif ($path === '/openapi.json') {
-                $jsonPath = storage_path('app/prism/openapi.json');
+                $jsonPath = storage_path('app/spectrum/openapi.json');
                 $json = file_exists($jsonPath) ? file_get_contents($jsonPath) : '{}';
 
                 $connection->send(new Response(200, [
@@ -96,8 +96,8 @@ class LiveReloadServer
     private function getSwaggerUIHtml(): string
     {
         // Check if we're in a Laravel app with view support
-        if (function_exists('view') && view()->exists('prism::live-preview')) {
-            return view('prism::live-preview', ['wsPort' => 8081])->render();
+        if (function_exists('view') && view()->exists('spectrum::live-preview')) {
+            return view('spectrum::live-preview', ['wsPort' => 8081])->render();
         }
 
         // Fallback HTML for testing

--- a/src/SpectrumServiceProvider.php
+++ b/src/SpectrumServiceProvider.php
@@ -1,35 +1,35 @@
 <?php
 
-namespace LaravelPrism;
+namespace LaravelSpectrum;
 
 use Illuminate\Support\ServiceProvider;
-use LaravelPrism\Analyzers\AuthenticationAnalyzer;
-use LaravelPrism\Analyzers\ControllerAnalyzer;
-use LaravelPrism\Analyzers\FormRequestAnalyzer;
-use LaravelPrism\Analyzers\FractalTransformerAnalyzer;
-use LaravelPrism\Analyzers\InlineValidationAnalyzer;
-use LaravelPrism\Analyzers\ResourceAnalyzer;
-use LaravelPrism\Analyzers\RouteAnalyzer;
-use LaravelPrism\Console\CacheCommand;
-use LaravelPrism\Console\GenerateDocsCommand;
-use LaravelPrism\Console\WatchCommand;
-use LaravelPrism\Generators\ErrorResponseGenerator;
-use LaravelPrism\Generators\OpenApiGenerator;
-use LaravelPrism\Generators\SchemaGenerator;
-use LaravelPrism\Generators\SecuritySchemeGenerator;
-use LaravelPrism\Generators\ValidationMessageGenerator;
-use LaravelPrism\Services\DocumentationCache;
-use LaravelPrism\Services\FileWatcher;
-use LaravelPrism\Services\LiveReloadServer;
-use LaravelPrism\Support\TypeInference;
+use LaravelSpectrum\Analyzers\AuthenticationAnalyzer;
+use LaravelSpectrum\Analyzers\ControllerAnalyzer;
+use LaravelSpectrum\Analyzers\FormRequestAnalyzer;
+use LaravelSpectrum\Analyzers\FractalTransformerAnalyzer;
+use LaravelSpectrum\Analyzers\InlineValidationAnalyzer;
+use LaravelSpectrum\Analyzers\ResourceAnalyzer;
+use LaravelSpectrum\Analyzers\RouteAnalyzer;
+use LaravelSpectrum\Console\CacheCommand;
+use LaravelSpectrum\Console\GenerateDocsCommand;
+use LaravelSpectrum\Console\WatchCommand;
+use LaravelSpectrum\Generators\ErrorResponseGenerator;
+use LaravelSpectrum\Generators\OpenApiGenerator;
+use LaravelSpectrum\Generators\SchemaGenerator;
+use LaravelSpectrum\Generators\SecuritySchemeGenerator;
+use LaravelSpectrum\Generators\ValidationMessageGenerator;
+use LaravelSpectrum\Services\DocumentationCache;
+use LaravelSpectrum\Services\FileWatcher;
+use LaravelSpectrum\Services\LiveReloadServer;
+use LaravelSpectrum\Support\TypeInference;
 
-class PrismServiceProvider extends ServiceProvider
+class SpectrumServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
         $this->mergeConfigFrom(
-            __DIR__.'/../config/prism.php',
-            'prism'
+            __DIR__.'/../config/spectrum.php',
+            'spectrum'
         );
 
         // シングルトンとして登録
@@ -64,15 +64,15 @@ class PrismServiceProvider extends ServiceProvider
     {
         // 設定ファイルの公開
         $this->publishes([
-            __DIR__.'/../config/prism.php' => config_path('prism.php'),
-        ], 'prism-config');
+            __DIR__.'/../config/spectrum.php' => config_path('spectrum.php'),
+        ], 'spectrum-config');
 
         // ビューの登録
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'prism');
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'spectrum');
 
         // ビューの公開
         $this->publishes([
-            __DIR__.'/../resources/views' => resource_path('views/vendor/prism'),
-        ], 'prism-views');
+            __DIR__.'/../resources/views' => resource_path('views/vendor/spectrum'),
+        ], 'spectrum-views');
     }
 }

--- a/src/Support/AuthenticationDetector.php
+++ b/src/Support/AuthenticationDetector.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Support;
+namespace LaravelSpectrum\Support;
 
 use Illuminate\Support\Str;
 

--- a/src/Support/LumenCompatibilityHelper.php
+++ b/src/Support/LumenCompatibilityHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Support;
+namespace LaravelSpectrum\Support;
 
 use Illuminate\Support\Facades\Route;
 
@@ -22,11 +22,11 @@ class LumenCompatibilityHelper
     {
         if (self::isLumen()) {
             // Lumenの場合、デフォルトでAPIルートのみ
-            return config('prism.route_patterns', ['*']);
+            return config('spectrum.route_patterns', ['*']);
         }
 
         // Laravelの場合
-        return config('prism.route_patterns', ['api/*']);
+        return config('spectrum.route_patterns', ['api/*']);
     }
 
     /**

--- a/src/Support/TypeInference.php
+++ b/src/Support/TypeInference.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Support;
+namespace LaravelSpectrum\Support;
 
 use Illuminate\Support\Str;
 

--- a/src/Support/ValidationRules.php
+++ b/src/Support/ValidationRules.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Support;
+namespace LaravelSpectrum\Support;
 
 class ValidationRules
 {

--- a/tests/Feature/AuthenticationIntegrationTest.php
+++ b/tests/Feature/AuthenticationIntegrationTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace LaravelPrism\Tests\Feature;
+namespace LaravelSpectrum\Tests\Feature;
 
 use Illuminate\Support\Facades\Route;
-use LaravelPrism\Cache\DocumentationCache;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Cache\DocumentationCache;
+use LaravelSpectrum\Tests\TestCase;
 
 class AuthenticationIntegrationTest extends TestCase
 {
@@ -74,7 +74,7 @@ class AuthenticationIntegrationTest extends TestCase
         });
 
         // OAuth2設定
-        config(['prism.authentication.oauth2' => [
+        config(['spectrum.authentication.oauth2' => [
             'authorization_url' => 'https://example.com/oauth/authorize',
             'token_url' => 'https://example.com/oauth/token',
             'scopes' => [

--- a/tests/Feature/CacheCommandTest.php
+++ b/tests/Feature/CacheCommandTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace LaravelPrism\Tests\Feature;
+namespace LaravelSpectrum\Tests\Feature;
 
 use Illuminate\Support\Facades\Route;
-use LaravelPrism\Cache\DocumentationCache;
-use LaravelPrism\Tests\Fixtures\Controllers\UserController;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Cache\DocumentationCache;
+use LaravelSpectrum\Tests\Fixtures\Controllers\UserController;
+use LaravelSpectrum\Tests\TestCase;
 
 class CacheCommandTest extends TestCase
 {
@@ -33,7 +33,7 @@ class CacheCommandTest extends TestCase
         $cache->remember('test_key', fn () => 'test_data');
 
         // Act
-        $this->artisan('prism:cache clear')
+        $this->artisan('spectrum:cache clear')
             ->expectsOutput('🧹 Clearing cache...')
             ->expectsOutput('✅ Cache cleared successfully')
             ->assertSuccessful();
@@ -52,7 +52,7 @@ class CacheCommandTest extends TestCase
         $cache->remember('key2', fn () => 'data2');
 
         // Act
-        $this->artisan('prism:cache stats')
+        $this->artisan('spectrum:cache stats')
             ->expectsOutput('📊 Cache Statistics')
             ->expectsOutput('==================')
             ->expectsOutput('Status: Enabled')
@@ -67,7 +67,7 @@ class CacheCommandTest extends TestCase
         Route::get('api/users', [UserController::class, 'index']);
 
         // Act
-        $this->artisan('prism:cache warm')
+        $this->artisan('spectrum:cache warm')
             ->expectsOutput('🔥 Warming cache...')
             ->expectsOutputToContain('✅ Cache warmed:')
             ->assertSuccessful();
@@ -80,7 +80,7 @@ class CacheCommandTest extends TestCase
     /** @test */
     public function it_shows_error_for_invalid_action()
     {
-        $this->artisan('prism:cache invalid')
+        $this->artisan('spectrum:cache invalid')
             ->expectsOutput('Invalid action. Use: clear, stats, or warm')
             ->assertFailed();
     }

--- a/tests/Feature/ErrorResponseIntegrationTest.php
+++ b/tests/Feature/ErrorResponseIntegrationTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace LaravelPrism\Tests\Feature;
+namespace LaravelSpectrum\Tests\Feature;
 
 use Illuminate\Support\Facades\Route;
-use LaravelPrism\Cache\DocumentationCache;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Cache\DocumentationCache;
+use LaravelSpectrum\Tests\TestCase;
 
 class ErrorResponseIntegrationTest extends TestCase
 {
@@ -22,8 +22,8 @@ class ErrorResponseIntegrationTest extends TestCase
         app(DocumentationCache::class)->clear();
 
         // テスト後のクリーンアップ
-        if (\Illuminate\Support\Facades\File::exists(storage_path('app/prism'))) {
-            \Illuminate\Support\Facades\File::deleteDirectory(storage_path('app/prism'));
+        if (\Illuminate\Support\Facades\File::exists(storage_path('app/spectrum'))) {
+            \Illuminate\Support\Facades\File::deleteDirectory(storage_path('app/spectrum'));
         }
 
         parent::tearDown();
@@ -39,10 +39,10 @@ class ErrorResponseIntegrationTest extends TestCase
             ->name('users.show');
 
         // OpenAPI仕様を生成
-        $this->artisan('prism:generate')->assertExitCode(0);
+        $this->artisan('spectrum:generate')->assertExitCode(0);
 
         // 生成されたファイルを読み込む
-        $openapi = json_decode(file_get_contents(storage_path('app/prism/openapi.json')), true);
+        $openapi = json_decode(file_get_contents(storage_path('app/spectrum/openapi.json')), true);
 
         // POST /api/users のエラーレスポンスを確認
         $postResponses = $openapi['paths']['/api/users']['post']['responses'];

--- a/tests/Feature/GenerateDocsCommandTest.php
+++ b/tests/Feature/GenerateDocsCommandTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace LaravelPrism\Tests\Feature;
+namespace LaravelSpectrum\Tests\Feature;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
-use LaravelPrism\Cache\DocumentationCache;
-use LaravelPrism\Tests\Fixtures\Controllers\UserController;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Cache\DocumentationCache;
+use LaravelSpectrum\Tests\Fixtures\Controllers\UserController;
+use LaravelSpectrum\Tests\TestCase;
 
 class GenerateDocsCommandTest extends TestCase
 {
@@ -21,8 +21,8 @@ class GenerateDocsCommandTest extends TestCase
     protected function tearDown(): void
     {
         // テスト後のクリーンアップ
-        if (File::exists(storage_path('app/prism'))) {
-            File::deleteDirectory(storage_path('app/prism'));
+        if (File::exists(storage_path('app/spectrum'))) {
+            File::deleteDirectory(storage_path('app/spectrum'));
         }
 
         // Clear cache after test
@@ -39,16 +39,16 @@ class GenerateDocsCommandTest extends TestCase
         Route::post('api/users', [UserController::class, 'store']);
 
         // Act
-        $this->artisan('prism:generate')
+        $this->artisan('spectrum:generate')
             ->expectsOutput('🔍 Analyzing routes...')
             ->expectsOutput('Found 2 API routes')
             ->expectsOutput('📝 Generating OpenAPI specification...')
             ->assertSuccessful();
 
         // Assert
-        $this->assertFileExists(storage_path('app/prism/openapi.json'));
+        $this->assertFileExists(storage_path('app/spectrum/openapi.json'));
 
-        $content = File::get(storage_path('app/prism/openapi.json'));
+        $content = File::get(storage_path('app/spectrum/openapi.json'));
         $openapi = json_decode($content, true);
 
         $this->assertEquals('3.0.0', $openapi['openapi']);
@@ -65,7 +65,7 @@ class GenerateDocsCommandTest extends TestCase
         app(DocumentationCache::class)->remember('test_key', fn () => 'test_data');
 
         // Act
-        $this->artisan('prism:generate --clear-cache')
+        $this->artisan('spectrum:generate --clear-cache')
             ->expectsOutput('🧹 Clearing cache...')
             ->expectsOutput('🔍 Analyzing routes...')
             ->assertSuccessful();
@@ -82,7 +82,7 @@ class GenerateDocsCommandTest extends TestCase
         Route::get('api/users', [UserController::class, 'index']);
 
         // Act
-        $this->artisan('prism:generate --no-cache')
+        $this->artisan('spectrum:generate --no-cache')
             ->expectsOutput('🔍 Analyzing routes...')
             ->doesntExpectOutput('💾 Cache:')
             ->assertSuccessful();
@@ -95,13 +95,13 @@ class GenerateDocsCommandTest extends TestCase
         Route::get('api/users', [UserController::class, 'index']);
 
         // Act
-        $this->artisan('prism:generate', ['--format' => 'yaml'])
+        $this->artisan('spectrum:generate', ['--format' => 'yaml'])
             ->assertSuccessful();
 
         // Assert
-        $this->assertFileExists(storage_path('app/prism/openapi.yaml'));
+        $this->assertFileExists(storage_path('app/spectrum/openapi.yaml'));
 
-        $content = File::get(storage_path('app/prism/openapi.yaml'));
+        $content = File::get(storage_path('app/spectrum/openapi.yaml'));
         $this->assertStringContainsString('openapi: 3.0.0', $content);
     }
 
@@ -113,7 +113,7 @@ class GenerateDocsCommandTest extends TestCase
         $customPath = storage_path('custom/api-docs.json');
 
         // Act
-        $this->artisan('prism:generate', ['--output' => $customPath])
+        $this->artisan('spectrum:generate', ['--output' => $customPath])
             ->assertSuccessful();
 
         // Assert
@@ -130,8 +130,8 @@ class GenerateDocsCommandTest extends TestCase
         // Arrange - No routes configured
 
         // Act
-        $this->artisan('prism:generate')
-            ->expectsOutput('No API routes found. Make sure your routes match the patterns in config/prism.php')
+        $this->artisan('spectrum:generate')
+            ->expectsOutput('No API routes found. Make sure your routes match the patterns in config/spectrum.php')
             ->assertFailed();
     }
 }

--- a/tests/Feature/LumenCompatibilityTest.php
+++ b/tests/Feature/LumenCompatibilityTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace LaravelPrism\Tests\Feature;
+namespace LaravelSpectrum\Tests\Feature;
 
-use LaravelPrism\Analyzers\ControllerAnalyzer;
-use LaravelPrism\Analyzers\FormRequestAnalyzer;
-use LaravelPrism\Analyzers\InlineValidationAnalyzer;
-use LaravelPrism\Generators\OpenApiGenerator;
-use LaravelPrism\Support\LumenCompatibilityHelper;
-use LaravelPrism\Support\TypeInference;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Analyzers\ControllerAnalyzer;
+use LaravelSpectrum\Analyzers\FormRequestAnalyzer;
+use LaravelSpectrum\Analyzers\InlineValidationAnalyzer;
+use LaravelSpectrum\Generators\OpenApiGenerator;
+use LaravelSpectrum\Support\LumenCompatibilityHelper;
+use LaravelSpectrum\Support\TypeInference;
+use LaravelSpectrum\Tests\TestCase;
 
 class LumenCompatibilityTest extends TestCase
 {
@@ -22,7 +22,7 @@ class LumenCompatibilityTest extends TestCase
     /** @test */
     public function it_returns_correct_route_patterns_for_laravel()
     {
-        config(['prism.route_patterns' => ['api/*']]);
+        config(['spectrum.route_patterns' => ['api/*']]);
 
         $patterns = LumenCompatibilityHelper::getRoutePatterns();
 

--- a/tests/Feature/OpenApiGeneratorTest.php
+++ b/tests/Feature/OpenApiGeneratorTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace LaravelPrism\Tests\Feature;
+namespace LaravelSpectrum\Tests\Feature;
 
 use Illuminate\Support\Facades\Route;
-use LaravelPrism\Analyzers\RouteAnalyzer;
-use LaravelPrism\Cache\DocumentationCache;
-use LaravelPrism\Generators\OpenApiGenerator;
-use LaravelPrism\Tests\Fixtures\Controllers\ProfileController;
-use LaravelPrism\Tests\Fixtures\Controllers\UserController;
-use LaravelPrism\Tests\Fixtures\StoreUserRequest;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Analyzers\RouteAnalyzer;
+use LaravelSpectrum\Cache\DocumentationCache;
+use LaravelSpectrum\Generators\OpenApiGenerator;
+use LaravelSpectrum\Tests\Fixtures\Controllers\ProfileController;
+use LaravelSpectrum\Tests\Fixtures\Controllers\UserController;
+use LaravelSpectrum\Tests\Fixtures\StoreUserRequest;
+use LaravelSpectrum\Tests\TestCase;
 use Mockery;
 
 class OpenApiGeneratorTest extends TestCase
@@ -120,9 +120,9 @@ class OpenApiGeneratorTest extends TestCase
     public function it_includes_api_info_and_servers()
     {
         // Arrange
-        config(['prism.title' => 'Test API']);
-        config(['prism.version' => '2.0.0']);
-        config(['prism.description' => 'Test API Description']);
+        config(['spectrum.title' => 'Test API']);
+        config(['spectrum.version' => '2.0.0']);
+        config(['spectrum.description' => 'Test API Description']);
         config(['app.url' => 'https://example.com']);
 
         Route::get('api/test', [UserController::class, 'index']);

--- a/tests/Feature/WatchCommandIntegrationTest.php
+++ b/tests/Feature/WatchCommandIntegrationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Tests\Feature;
+namespace LaravelSpectrum\Tests\Feature;
 
 use Illuminate\Support\Facades\File;
 use Orchestra\Testbench\TestCase;
@@ -14,7 +14,7 @@ class WatchCommandIntegrationTest extends TestCase
     {
         parent::setUp();
 
-        $this->tempDir = sys_get_temp_dir().'/prism_watch_test_'.uniqid();
+        $this->tempDir = sys_get_temp_dir().'/spectrum_watch_test_'.uniqid();
         File::makeDirectory($this->tempDir, 0777, true, true);
         File::makeDirectory($this->tempDir.'/app/Http/Controllers', 0777, true, true);
         File::makeDirectory($this->tempDir.'/app/Http/Requests', 0777, true, true);
@@ -22,7 +22,7 @@ class WatchCommandIntegrationTest extends TestCase
 
         // Set up config
         config([
-            'prism.watch.paths' => [
+            'spectrum.watch.paths' => [
                 $this->tempDir.'/app/Http/Controllers',
                 $this->tempDir.'/app/Http/Requests',
                 $this->tempDir.'/routes',

--- a/tests/Fixtures/BooleanTestResource.php
+++ b/tests/Fixtures/BooleanTestResource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Tests\Fixtures;
+namespace LaravelSpectrum\Tests\Fixtures;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 

--- a/tests/Fixtures/CollectionTestResource.php
+++ b/tests/Fixtures/CollectionTestResource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Tests\Fixtures;
+namespace LaravelSpectrum\Tests\Fixtures;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 

--- a/tests/Fixtures/Controllers/AdminController.php
+++ b/tests/Fixtures/Controllers/AdminController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Tests\Fixtures\Controllers;
+namespace LaravelSpectrum\Tests\Fixtures\Controllers;
 
 use Illuminate\Http\JsonResponse;
 

--- a/tests/Fixtures/Controllers/CommentController.php
+++ b/tests/Fixtures/Controllers/CommentController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Tests\Fixtures\Controllers;
+namespace LaravelSpectrum\Tests\Fixtures\Controllers;
 
 class CommentController
 {

--- a/tests/Fixtures/Controllers/OAuthController.php
+++ b/tests/Fixtures/Controllers/OAuthController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Tests\Fixtures\Controllers;
+namespace LaravelSpectrum\Tests\Fixtures\Controllers;
 
 use Illuminate\Http\JsonResponse;
 

--- a/tests/Fixtures/Controllers/PageController.php
+++ b/tests/Fixtures/Controllers/PageController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Tests\Fixtures\Controllers;
+namespace LaravelSpectrum\Tests\Fixtures\Controllers;
 
 class PageController
 {

--- a/tests/Fixtures/Controllers/PostController.php
+++ b/tests/Fixtures/Controllers/PostController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Tests\Fixtures\Controllers;
+namespace LaravelSpectrum\Tests\Fixtures\Controllers;
 
 use Illuminate\Http\JsonResponse;
 

--- a/tests/Fixtures/Controllers/ProfileController.php
+++ b/tests/Fixtures/Controllers/ProfileController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Tests\Fixtures\Controllers;
+namespace LaravelSpectrum\Tests\Fixtures\Controllers;
 
 use Illuminate\Http\JsonResponse;
 

--- a/tests/Fixtures/Controllers/SearchController.php
+++ b/tests/Fixtures/Controllers/SearchController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Tests\Fixtures\Controllers;
+namespace LaravelSpectrum\Tests\Fixtures\Controllers;
 
 class SearchController
 {

--- a/tests/Fixtures/Controllers/UserController.php
+++ b/tests/Fixtures/Controllers/UserController.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace LaravelPrism\Tests\Fixtures\Controllers;
+namespace LaravelSpectrum\Tests\Fixtures\Controllers;
 
-use LaravelPrism\Tests\Fixtures\StoreUserRequest;
-use LaravelPrism\Tests\Fixtures\UserResource;
+use LaravelSpectrum\Tests\Fixtures\StoreUserRequest;
+use LaravelSpectrum\Tests\Fixtures\UserResource;
 
 class UserController
 {

--- a/tests/Fixtures/DateTestResource.php
+++ b/tests/Fixtures/DateTestResource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Tests\Fixtures;
+namespace LaravelSpectrum\Tests\Fixtures;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 

--- a/tests/Fixtures/NestedTestResource.php
+++ b/tests/Fixtures/NestedTestResource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Tests\Fixtures;
+namespace LaravelSpectrum\Tests\Fixtures;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 

--- a/tests/Fixtures/StoreUserRequest.php
+++ b/tests/Fixtures/StoreUserRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Tests\Fixtures;
+namespace LaravelSpectrum\Tests\Fixtures;
 
 use Illuminate\Foundation\Http\FormRequest;
 

--- a/tests/Fixtures/Transformers/CommentTransformer.php
+++ b/tests/Fixtures/Transformers/CommentTransformer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Tests\Fixtures\Transformers;
+namespace LaravelSpectrum\Tests\Fixtures\Transformers;
 
 use League\Fractal\TransformerAbstract;
 

--- a/tests/Fixtures/Transformers/ComplexTransformer.php
+++ b/tests/Fixtures/Transformers/ComplexTransformer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Tests\Fixtures\Transformers;
+namespace LaravelSpectrum\Tests\Fixtures\Transformers;
 
 use League\Fractal\TransformerAbstract;
 

--- a/tests/Fixtures/Transformers/PostTransformer.php
+++ b/tests/Fixtures/Transformers/PostTransformer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Tests\Fixtures\Transformers;
+namespace LaravelSpectrum\Tests\Fixtures\Transformers;
 
 use League\Fractal\TransformerAbstract;
 

--- a/tests/Fixtures/Transformers/ProfileTransformer.php
+++ b/tests/Fixtures/Transformers/ProfileTransformer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Tests\Fixtures\Transformers;
+namespace LaravelSpectrum\Tests\Fixtures\Transformers;
 
 use League\Fractal\TransformerAbstract;
 

--- a/tests/Fixtures/Transformers/UserTransformer.php
+++ b/tests/Fixtures/Transformers/UserTransformer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Tests\Fixtures\Transformers;
+namespace LaravelSpectrum\Tests\Fixtures\Transformers;
 
 use League\Fractal\TransformerAbstract;
 

--- a/tests/Fixtures/UserResource.php
+++ b/tests/Fixtures/UserResource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace LaravelPrism\Tests\Fixtures;
+namespace LaravelSpectrum\Tests\Fixtures;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 

--- a/tests/Performance/CachePerformanceTest.php
+++ b/tests/Performance/CachePerformanceTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace LaravelPrism\Tests\Performance;
+namespace LaravelSpectrum\Tests\Performance;
 
 use Illuminate\Support\Facades\Route;
-use LaravelPrism\Analyzers\RouteAnalyzer;
-use LaravelPrism\Cache\DocumentationCache;
-use LaravelPrism\Tests\Fixtures\Controllers\UserController;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Analyzers\RouteAnalyzer;
+use LaravelSpectrum\Cache\DocumentationCache;
+use LaravelSpectrum\Tests\Fixtures\Controllers\UserController;
+use LaravelSpectrum\Tests\TestCase;
 
 class CachePerformanceTest extends TestCase
 {
@@ -36,7 +36,7 @@ class CachePerformanceTest extends TestCase
         }
 
         // キャッシュなしの時間を計測
-        config(['prism.cache.enabled' => false]);
+        config(['spectrum.cache.enabled' => false]);
         $analyzer = app(RouteAnalyzer::class);
 
         $startTime = microtime(true);
@@ -44,7 +44,7 @@ class CachePerformanceTest extends TestCase
         $withoutCache = microtime(true) - $startTime;
 
         // キャッシュありの時間を計測
-        config(['prism.cache.enabled' => true]);
+        config(['spectrum.cache.enabled' => true]);
         app()->forgetInstance(RouteAnalyzer::class);
         $analyzer = app(RouteAnalyzer::class);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace LaravelPrism\Tests;
+namespace LaravelSpectrum\Tests;
 
-use LaravelPrism\Analyzers\RouteAnalyzer;
-use LaravelPrism\Generators\OpenApiGenerator;
-use LaravelPrism\PrismServiceProvider;
+use LaravelSpectrum\Analyzers\RouteAnalyzer;
+use LaravelSpectrum\Generators\OpenApiGenerator;
+use LaravelSpectrum\SpectrumServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 abstract class TestCase extends Orchestra
@@ -12,13 +12,13 @@ abstract class TestCase extends Orchestra
     protected function getPackageProviders($app)
     {
         return [
-            PrismServiceProvider::class,
+            SpectrumServiceProvider::class,
         ];
     }
 
     protected function defineEnvironment($app)
     {
-        $app['config']->set('prism.route_patterns', ['api/*']);
+        $app['config']->set('spectrum.route_patterns', ['api/*']);
     }
 
     protected function generateOpenApi(): array

--- a/tests/Unit/Analyzers/AST/ConditionalRulesTest.php
+++ b/tests/Unit/Analyzers/AST/ConditionalRulesTest.php
@@ -3,10 +3,10 @@
 namespace Tests\Unit\Analyzers\AST;
 
 use Illuminate\Foundation\Http\FormRequest;
-use LaravelPrism\Analyzers\FormRequestAnalyzer;
-use LaravelPrism\Cache\DocumentationCache;
-use LaravelPrism\Support\TypeInference;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Analyzers\FormRequestAnalyzer;
+use LaravelSpectrum\Cache\DocumentationCache;
+use LaravelSpectrum\Support\TypeInference;
+use LaravelSpectrum\Tests\TestCase;
 
 class ConditionalRulesTest extends TestCase
 {

--- a/tests/Unit/Analyzers/AuthenticationAnalyzerTest.php
+++ b/tests/Unit/Analyzers/AuthenticationAnalyzerTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace LaravelPrism\Tests\Unit\Analyzers;
+namespace LaravelSpectrum\Tests\Unit\Analyzers;
 
-use LaravelPrism\Analyzers\AuthenticationAnalyzer;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Analyzers\AuthenticationAnalyzer;
+use LaravelSpectrum\Tests\TestCase;
 
 class AuthenticationAnalyzerTest extends TestCase
 {
@@ -78,7 +78,7 @@ class AuthenticationAnalyzerTest extends TestCase
     /** @test */
     public function it_loads_custom_schemes_from_config()
     {
-        config(['prism.authentication.custom_schemes' => [
+        config(['spectrum.authentication.custom_schemes' => [
             'jwt-auth' => [
                 'type' => 'http',
                 'scheme' => 'bearer',
@@ -104,7 +104,7 @@ class AuthenticationAnalyzerTest extends TestCase
     /** @test */
     public function it_gets_global_authentication_when_enabled()
     {
-        config(['prism.authentication.global' => [
+        config(['spectrum.authentication.global' => [
             'enabled' => true,
             'scheme' => [
                 'type' => 'http',
@@ -125,7 +125,7 @@ class AuthenticationAnalyzerTest extends TestCase
     /** @test */
     public function it_returns_null_when_global_authentication_is_disabled()
     {
-        config(['prism.authentication.global' => [
+        config(['spectrum.authentication.global' => [
             'enabled' => false,
         ]]);
 

--- a/tests/Unit/Analyzers/ControllerAnalyzerTest.php
+++ b/tests/Unit/Analyzers/ControllerAnalyzerTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace LaravelPrism\Tests\Unit\Analyzers;
+namespace LaravelSpectrum\Tests\Unit\Analyzers;
 
-use LaravelPrism\Analyzers\ControllerAnalyzer;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Analyzers\ControllerAnalyzer;
+use LaravelSpectrum\Tests\TestCase;
 
 class ControllerAnalyzerTest extends TestCase
 {

--- a/tests/Unit/Analyzers/FractalTransformerAnalyzerTest.php
+++ b/tests/Unit/Analyzers/FractalTransformerAnalyzerTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace LaravelPrism\Tests\Unit\Analyzers;
+namespace LaravelSpectrum\Tests\Unit\Analyzers;
 
-use LaravelPrism\Analyzers\FractalTransformerAnalyzer;
-use LaravelPrism\Tests\Fixtures\Transformers\ComplexTransformer;
-use LaravelPrism\Tests\Fixtures\Transformers\PostTransformer;
-use LaravelPrism\Tests\Fixtures\Transformers\UserTransformer;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Analyzers\FractalTransformerAnalyzer;
+use LaravelSpectrum\Tests\Fixtures\Transformers\ComplexTransformer;
+use LaravelSpectrum\Tests\Fixtures\Transformers\PostTransformer;
+use LaravelSpectrum\Tests\Fixtures\Transformers\UserTransformer;
+use LaravelSpectrum\Tests\TestCase;
 
 class FractalTransformerAnalyzerTest extends TestCase
 {

--- a/tests/Unit/Analyzers/InlineValidationAnalyzerTest.php
+++ b/tests/Unit/Analyzers/InlineValidationAnalyzerTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace LaravelPrism\Tests\Unit\Analyzers;
+namespace LaravelSpectrum\Tests\Unit\Analyzers;
 
-use LaravelPrism\Analyzers\InlineValidationAnalyzer;
-use LaravelPrism\Support\TypeInference;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Analyzers\InlineValidationAnalyzer;
+use LaravelSpectrum\Support\TypeInference;
+use LaravelSpectrum\Tests\TestCase;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;

--- a/tests/Unit/Console/WatchCommandTest.php
+++ b/tests/Unit/Console/WatchCommandTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace LaravelPrism\Tests\Unit\Console;
+namespace LaravelSpectrum\Tests\Unit\Console;
 
-use LaravelPrism\Console\WatchCommand;
-use LaravelPrism\Services\DocumentationCache;
-use LaravelPrism\Services\FileWatcher;
-use LaravelPrism\Services\LiveReloadServer;
+use LaravelSpectrum\Console\WatchCommand;
+use LaravelSpectrum\Services\DocumentationCache;
+use LaravelSpectrum\Services\FileWatcher;
+use LaravelSpectrum\Services\LiveReloadServer;
 use Mockery;
 use Orchestra\Testbench\TestCase;
 
@@ -26,7 +26,7 @@ class WatchCommandTest extends TestCase
         $command = new WatchCommand($fileWatcher, $server, $cache);
 
         $this->assertInstanceOf(WatchCommand::class, $command);
-        $this->assertEquals('prism:watch', $command->getName());
+        $this->assertEquals('spectrum:watch', $command->getName());
         $this->assertEquals('Start real-time documentation preview', $command->getDescription());
     }
 
@@ -197,7 +197,7 @@ class WatchCommandTest extends TestCase
         $command = new WatchCommand($fileWatcher, $server, $cache);
 
         // Set custom config
-        config(['prism.watch.paths' => [
+        config(['spectrum.watch.paths' => [
             '/custom/path1',
             '/custom/path2',
         ]]);
@@ -220,7 +220,7 @@ class WatchCommandTest extends TestCase
         $command = new WatchCommand($fileWatcher, $server, $cache);
 
         // Clear config to use defaults
-        config(['prism.watch.paths' => null]);
+        config(['spectrum.watch.paths' => null]);
 
         $reflection = new \ReflectionClass($command);
         $method = $reflection->getMethod('getWatchPaths');

--- a/tests/Unit/DocumentationCacheTest.php
+++ b/tests/Unit/DocumentationCacheTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace LaravelPrism\Tests\Unit;
+namespace LaravelSpectrum\Tests\Unit;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\File;
-use LaravelPrism\Cache\DocumentationCache;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Cache\DocumentationCache;
+use LaravelSpectrum\Tests\TestCase;
 
 class DocumentationCacheTest extends TestCase
 {
@@ -134,7 +134,7 @@ class DocumentationCacheTest extends TestCase
     /** @test */
     public function it_handles_corrupted_cache_gracefully()
     {
-        $cacheDir = config('prism.cache.directory', storage_path('app/prism/cache'));
+        $cacheDir = config('spectrum.cache.directory', storage_path('app/spectrum/cache'));
         $cacheFile = $cacheDir.'/'.sha1('corrupt_key').'.cache';
 
         // 破損したキャッシュファイルを作成
@@ -158,7 +158,7 @@ class DocumentationCacheTest extends TestCase
     public function it_respects_cache_enabled_setting()
     {
         // キャッシュを無効化
-        config(['prism.cache.enabled' => false]);
+        config(['spectrum.cache.enabled' => false]);
         $cache = new DocumentationCache;
 
         $callCount = 0;

--- a/tests/Unit/FormRequestAnalyzerTest.php
+++ b/tests/Unit/FormRequestAnalyzerTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace LaravelPrism\Tests\Unit;
+namespace LaravelSpectrum\Tests\Unit;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
-use LaravelPrism\Analyzers\FormRequestAnalyzer;
-use LaravelPrism\Cache\DocumentationCache;
-use LaravelPrism\Support\TypeInference;
-use LaravelPrism\Tests\Fixtures\StoreUserRequest;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Analyzers\FormRequestAnalyzer;
+use LaravelSpectrum\Cache\DocumentationCache;
+use LaravelSpectrum\Support\TypeInference;
+use LaravelSpectrum\Tests\Fixtures\StoreUserRequest;
+use LaravelSpectrum\Tests\TestCase;
 
 class FormRequestAnalyzerTest extends TestCase
 {

--- a/tests/Unit/Generators/ConditionalSchemaGeneratorTest.php
+++ b/tests/Unit/Generators/ConditionalSchemaGeneratorTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit\Generators;
 
-use LaravelPrism\Generators\SchemaGenerator;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Generators\SchemaGenerator;
+use LaravelSpectrum\Tests\TestCase;
 
 class ConditionalSchemaGeneratorTest extends TestCase
 {

--- a/tests/Unit/Generators/ErrorResponseGeneratorTest.php
+++ b/tests/Unit/Generators/ErrorResponseGeneratorTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace LaravelPrism\Tests\Unit\Generators;
+namespace LaravelSpectrum\Tests\Unit\Generators;
 
-use LaravelPrism\Generators\ErrorResponseGenerator;
-use LaravelPrism\Generators\ValidationMessageGenerator;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Generators\ErrorResponseGenerator;
+use LaravelSpectrum\Generators\ValidationMessageGenerator;
+use LaravelSpectrum\Tests\TestCase;
 
 class ErrorResponseGeneratorTest extends TestCase
 {

--- a/tests/Unit/Generators/SchemaGeneratorTest.php
+++ b/tests/Unit/Generators/SchemaGeneratorTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace LaravelPrism\Tests\Unit\Generators;
+namespace LaravelSpectrum\Tests\Unit\Generators;
 
-use LaravelPrism\Generators\SchemaGenerator;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Generators\SchemaGenerator;
+use LaravelSpectrum\Tests\TestCase;
 
 class SchemaGeneratorTest extends TestCase
 {

--- a/tests/Unit/Generators/SecuritySchemeGeneratorTest.php
+++ b/tests/Unit/Generators/SecuritySchemeGeneratorTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace LaravelPrism\Tests\Unit\Generators;
+namespace LaravelSpectrum\Tests\Unit\Generators;
 
-use LaravelPrism\Generators\SecuritySchemeGenerator;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Generators\SecuritySchemeGenerator;
+use LaravelSpectrum\Tests\TestCase;
 
 class SecuritySchemeGeneratorTest extends TestCase
 {

--- a/tests/Unit/Generators/ValidationMessageGeneratorTest.php
+++ b/tests/Unit/Generators/ValidationMessageGeneratorTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace LaravelPrism\Tests\Unit\Generators;
+namespace LaravelSpectrum\Tests\Unit\Generators;
 
-use LaravelPrism\Generators\ValidationMessageGenerator;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Generators\ValidationMessageGenerator;
+use LaravelSpectrum\Tests\TestCase;
 
 class ValidationMessageGeneratorTest extends TestCase
 {

--- a/tests/Unit/ResourceAnalyzerTest.php
+++ b/tests/Unit/ResourceAnalyzerTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace LaravelPrism\Tests\Unit;
+namespace LaravelSpectrum\Tests\Unit;
 
-use LaravelPrism\Analyzers\ResourceAnalyzer;
-use LaravelPrism\Cache\DocumentationCache;
-use LaravelPrism\Tests\Fixtures\BooleanTestResource;
-use LaravelPrism\Tests\Fixtures\CollectionTestResource;
-use LaravelPrism\Tests\Fixtures\DateTestResource;
-use LaravelPrism\Tests\Fixtures\NestedTestResource;
-use LaravelPrism\Tests\Fixtures\UserResource;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Analyzers\ResourceAnalyzer;
+use LaravelSpectrum\Cache\DocumentationCache;
+use LaravelSpectrum\Tests\Fixtures\BooleanTestResource;
+use LaravelSpectrum\Tests\Fixtures\CollectionTestResource;
+use LaravelSpectrum\Tests\Fixtures\DateTestResource;
+use LaravelSpectrum\Tests\Fixtures\NestedTestResource;
+use LaravelSpectrum\Tests\Fixtures\UserResource;
+use LaravelSpectrum\Tests\TestCase;
 use Tests\Unit\Analyzers\Fixtures\ConditionalFieldsResource;
 use Tests\Unit\Analyzers\Fixtures\DateFormattingResource;
 use Tests\Unit\Analyzers\Fixtures\MethodChainResource;

--- a/tests/Unit/RouteAnalyzerTest.php
+++ b/tests/Unit/RouteAnalyzerTest.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace LaravelPrism\Tests\Unit;
+namespace LaravelSpectrum\Tests\Unit;
 
 use Illuminate\Support\Facades\Route;
-use LaravelPrism\Analyzers\RouteAnalyzer;
-use LaravelPrism\Cache\DocumentationCache;
-use LaravelPrism\Tests\Fixtures\Controllers\CommentController;
-use LaravelPrism\Tests\Fixtures\Controllers\PageController;
-use LaravelPrism\Tests\Fixtures\Controllers\ProfileController;
-use LaravelPrism\Tests\Fixtures\Controllers\SearchController;
-use LaravelPrism\Tests\Fixtures\Controllers\UserController;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Analyzers\RouteAnalyzer;
+use LaravelSpectrum\Cache\DocumentationCache;
+use LaravelSpectrum\Tests\Fixtures\Controllers\CommentController;
+use LaravelSpectrum\Tests\Fixtures\Controllers\PageController;
+use LaravelSpectrum\Tests\Fixtures\Controllers\ProfileController;
+use LaravelSpectrum\Tests\Fixtures\Controllers\SearchController;
+use LaravelSpectrum\Tests\Fixtures\Controllers\UserController;
+use LaravelSpectrum\Tests\TestCase;
 
 class RouteAnalyzerTest extends TestCase
 {
@@ -69,7 +69,7 @@ class RouteAnalyzerTest extends TestCase
     public function it_filters_routes_by_configured_patterns()
     {
         // Arrange
-        config(['prism.route_patterns' => ['api/v1/*']]);
+        config(['spectrum.route_patterns' => ['api/v1/*']]);
         Route::get('api/v1/users', [UserController::class, 'index']);
         Route::get('api/v2/users', [UserController::class, 'index']);
 

--- a/tests/Unit/Services/FileWatcherTest.php
+++ b/tests/Unit/Services/FileWatcherTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace LaravelPrism\Tests\Unit\Services;
+namespace LaravelSpectrum\Tests\Unit\Services;
 
-use LaravelPrism\Services\FileWatcher;
+use LaravelSpectrum\Services\FileWatcher;
 use Orchestra\Testbench\TestCase;
 
 class FileWatcherTest extends TestCase
@@ -15,7 +15,7 @@ class FileWatcherTest extends TestCase
     {
         parent::setUp();
         $this->watcher = new FileWatcher;
-        $this->tempDir = sys_get_temp_dir().'/prism_watcher_test_'.uniqid();
+        $this->tempDir = sys_get_temp_dir().'/spectrum_watcher_test_'.uniqid();
         mkdir($this->tempDir, 0777, true);
     }
 

--- a/tests/Unit/Services/LiveReloadServerTest.php
+++ b/tests/Unit/Services/LiveReloadServerTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace LaravelPrism\Tests\Unit\Services;
+namespace LaravelSpectrum\Tests\Unit\Services;
 
-use LaravelPrism\Services\LiveReloadServer;
+use LaravelSpectrum\Services\LiveReloadServer;
 use Orchestra\Testbench\TestCase;
 
 class LiveReloadServerTest extends TestCase

--- a/tests/Unit/Support/AuthenticationDetectorTest.php
+++ b/tests/Unit/Support/AuthenticationDetectorTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace LaravelPrism\Tests\Unit\Support;
+namespace LaravelSpectrum\Tests\Unit\Support;
 
-use LaravelPrism\Support\AuthenticationDetector;
-use LaravelPrism\Tests\TestCase;
+use LaravelSpectrum\Support\AuthenticationDetector;
+use LaravelSpectrum\Tests\TestCase;
 
 class AuthenticationDetectorTest extends TestCase
 {


### PR DESCRIPTION
# 概要

LaravelプロジェクトのAPIドキュメント自動生成ツールの名称を「laravel-prism」から「laravel-spectrum」に変更しました。

## 変更内容

プロジェクト全体で統一的に名称変更を実施しました。

- **パッケージ名の変更**
  - composer.jsonのパッケージ名を`wadakatu/laravel-prism`から`wadakatu/laravel-spectrum`に変更
  - GitHubリポジトリの参照URLを更新

- **名前空間の変更**
  - PHP名前空間を`LaravelPrism`から`LaravelSpectrum`に変更
  - 全てのソースファイルとテストファイルで名前空間を更新

- **ファイル名の変更**
  - `PrismServiceProvider.php` → `SpectrumServiceProvider.php`
  - `config/prism.php` → `config/spectrum.php`

- **設定参照の更新**
  - `config('prism.*')` → `config('spectrum.*')`
  - ストレージパス: `app/prism/` → `app/spectrum/`
  - キャッシュプレフィックス: `prism:` → `spectrum:`
  - ビュー名前空間: `prism::` → `spectrum::`

- **コマンドの変更**
  - `php artisan prism:generate` → `php artisan spectrum:generate`
  - `php artisan prism:watch` → `php artisan spectrum:watch`
  - `php artisan prism:cache` → `php artisan spectrum:cache`

- **ドキュメントの更新**
  - README.mdの全ての参照を更新
  - PHPUnitテストスイート名を更新

## 関連情報

- この変更により、プロジェクトの名称がより明確で覚えやすいものになりました
- 既存の機能には影響ありません
- 全てのテストとコード品質チェック（Laravel Pint、PHPStan）が正常に通過しています