### PR TITLE
Bugfix: GitHub Actionsバナー更新のdetached HEADエラーを修正

### DIFF
--- a/.github/workflows/update-banner.yml
+++ b/.github/workflows/update-banner.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update-banner:
@@ -15,12 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        # Use the default GITHUB_TOKEN for authentication
         token: ${{ secrets.GITHUB_TOKEN }}
-        # Checkout the default branch
-        ref: ${{ github.event.repository.default_branch }}
-        # Fetch full history to avoid detached HEAD
-        fetch-depth: 0
     
     - name: Get latest release version
       id: get_version
@@ -28,20 +24,49 @@ jobs:
         VERSION=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
         echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
     
+    - name: Create update branch
+      run: |
+        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        
+        # Create a new branch for the update
+        git checkout -b update-banner
+    
     - name: Update banner SVG
       run: |
         sed -i "s|<text x=\"100\" y=\"250\"[^>]*>[^<]*</text>|<text x=\"100\" y=\"250\" text-anchor=\"middle\" font-family=\"monospace\" font-size=\"16\" fill=\"#00FF00\">${{ steps.get_version.outputs.VERSION }}</text>|g" assets/banner.svg
     
     - name: Commit and push changes
       run: |
-        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git config --local user.name "github-actions[bot]"
-        
         # Check if there are changes
         if [[ -n $(git status --porcelain assets/banner.svg) ]]; then
           git add assets/banner.svg
           git commit -m "chore: update banner version to ${{ steps.get_version.outputs.VERSION }}"
-          git push
+          git push -f origin update-banner
         else
           echo "No changes to commit"
+          exit 0
         fi
+    
+    - name: Create and merge PR
+      if: success()
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Check if PR already exists
+        PR_EXISTS=$(gh pr list --head update-banner --json number --jq '. | length')
+        
+        if [ "$PR_EXISTS" -eq "0" ]; then
+          # Create new PR
+          gh pr create \
+            --title "chore: update banner version to ${{ steps.get_version.outputs.VERSION }}" \
+            --body "Automated PR to update banner version after release ${{ steps.get_version.outputs.VERSION }}" \
+            --base main \
+            --head update-banner
+        fi
+        
+        # Wait a moment for PR to be created
+        sleep 5
+        
+        # Auto-merge the PR
+        gh pr merge update-banner --merge --auto

--- a/.github/workflows/update-banner.yml
+++ b/.github/workflows/update-banner.yml
@@ -5,6 +5,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   update-banner:
     runs-on: ubuntu-latest
@@ -12,7 +15,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        # Use the default GITHUB_TOKEN for authentication
         token: ${{ secrets.GITHUB_TOKEN }}
+        # Checkout the default branch
+        ref: ${{ github.event.repository.default_branch }}
+        # Fetch full history to avoid detached HEAD
+        fetch-depth: 0
     
     - name: Get latest release version
       id: get_version
@@ -24,10 +32,16 @@ jobs:
       run: |
         sed -i "s|<text x=\"100\" y=\"250\"[^>]*>[^<]*</text>|<text x=\"100\" y=\"250\" text-anchor=\"middle\" font-family=\"monospace\" font-size=\"16\" fill=\"#00FF00\">${{ steps.get_version.outputs.VERSION }}</text>|g" assets/banner.svg
     
-    - name: Commit changes
+    - name: Commit and push changes
       run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git add assets/banner.svg
-        git diff --staged --quiet || git commit -m "chore: update banner version to ${{ steps.get_version.outputs.VERSION }}"
-        git push
+        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        
+        # Check if there are changes
+        if [[ -n $(git status --porcelain assets/banner.svg) ]]; then
+          git add assets/banner.svg
+          git commit -m "chore: update banner version to ${{ steps.get_version.outputs.VERSION }}"
+          git push
+        else
+          echo "No changes to commit"
+        fi


### PR DESCRIPTION
# 概要

GitHub Actionsでバナーバージョンを自動更新する際に発生していたdetached HEADエラーを修正しました。

## 変更内容

mainブランチへの直接プッシュ制限に対応するため、PR経由での更新方式に変更しました。

- **ワークフローの修正**
  - `update-banner`ブランチを作成してPRを作成する方式に変更
  - 自動マージ機能を追加（`update-banner`ブランチはCIチェックをスキップ可能）
  - `pull-requests: write`権限を追加

- **エラーの解決**
  - detached HEAD状態でのコミットエラーを回避
  - mainブランチの保護ルールに対応

- **処理フローの改善**
  - 既存のPRがある場合は重複作成を防止
  - 変更がない場合は処理をスキップ

## 関連情報

- 元のエラー: `fatal: You are not currently on a branch.`
- このワークフローはリリース時またはworkflow_dispatchで手動実行可能