### PR TITLE
Bugfix: SchemaGeneratorでexampleキーが存在しない場合のエラーを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ php artisan spectrum:watch
 ## 📦 Installation
 
 ```bash
-composer require wadakatu/laravel-spectrum
+composer require wadakatu/laravel-spectrum --dev
 ```
 
 That's it! No configuration needed to get started.

--- a/src/Generators/SchemaGenerator.php
+++ b/src/Generators/SchemaGenerator.php
@@ -80,11 +80,11 @@ class SchemaGenerator
             $schema = [
                 'type' => $info['type'],
             ];
-            
+
             if (isset($info['example'])) {
                 $schema['example'] = $info['example'];
             }
-            
+
             $properties[$field] = $schema;
         }
 

--- a/src/Generators/SchemaGenerator.php
+++ b/src/Generators/SchemaGenerator.php
@@ -77,10 +77,15 @@ class SchemaGenerator
         $properties = [];
 
         foreach ($resourceStructure as $field => $info) {
-            $properties[$field] = [
+            $schema = [
                 'type' => $info['type'],
-                'example' => $info['example'],
             ];
+            
+            if (isset($info['example'])) {
+                $schema['example'] = $info['example'];
+            }
+            
+            $properties[$field] = $schema;
         }
 
         return [

--- a/tests/Unit/Generators/SchemaGeneratorTest.php
+++ b/tests/Unit/Generators/SchemaGeneratorTest.php
@@ -175,19 +175,19 @@ class SchemaGeneratorTest extends TestCase
 
         $this->assertEquals('object', $schema['type']);
         $this->assertArrayHasKey('properties', $schema);
-        
+
         // Check that properties exist
         $this->assertArrayHasKey('id', $schema['properties']);
         $this->assertArrayHasKey('name', $schema['properties']);
         $this->assertArrayHasKey('email', $schema['properties']);
         $this->assertArrayHasKey('created_at', $schema['properties']);
-        
+
         // Check types
         $this->assertEquals('integer', $schema['properties']['id']['type']);
         $this->assertEquals('string', $schema['properties']['name']['type']);
         $this->assertEquals('string', $schema['properties']['email']['type']);
         $this->assertEquals('string', $schema['properties']['created_at']['type']);
-        
+
         // Check example key existence
         $this->assertArrayNotHasKey('example', $schema['properties']['id']);
         $this->assertArrayNotHasKey('example', $schema['properties']['name']);

--- a/tests/Unit/Generators/SchemaGeneratorTest.php
+++ b/tests/Unit/Generators/SchemaGeneratorTest.php
@@ -160,4 +160,39 @@ class SchemaGeneratorTest extends TestCase
         $this->assertEquals('object', $dataProperties['flags']['type']);
         $this->assertArrayHasKey('is_active', $dataProperties['flags']['properties']);
     }
+
+    /** @test */
+    public function it_generates_schema_from_resource_without_example_keys()
+    {
+        $resourceStructure = [
+            'id' => ['type' => 'integer'],
+            'name' => ['type' => 'string'],
+            'email' => ['type' => 'string', 'example' => 'user@example.com'],
+            'created_at' => ['type' => 'string'],
+        ];
+
+        $schema = $this->generator->generateFromResource($resourceStructure);
+
+        $this->assertEquals('object', $schema['type']);
+        $this->assertArrayHasKey('properties', $schema);
+        
+        // Check that properties exist
+        $this->assertArrayHasKey('id', $schema['properties']);
+        $this->assertArrayHasKey('name', $schema['properties']);
+        $this->assertArrayHasKey('email', $schema['properties']);
+        $this->assertArrayHasKey('created_at', $schema['properties']);
+        
+        // Check types
+        $this->assertEquals('integer', $schema['properties']['id']['type']);
+        $this->assertEquals('string', $schema['properties']['name']['type']);
+        $this->assertEquals('string', $schema['properties']['email']['type']);
+        $this->assertEquals('string', $schema['properties']['created_at']['type']);
+        
+        // Check example key existence
+        $this->assertArrayNotHasKey('example', $schema['properties']['id']);
+        $this->assertArrayNotHasKey('example', $schema['properties']['name']);
+        $this->assertArrayHasKey('example', $schema['properties']['email']);
+        $this->assertEquals('user@example.com', $schema['properties']['email']['example']);
+        $this->assertArrayNotHasKey('example', $schema['properties']['created_at']);
+    }
 }

--- a/tests/Unit/RouteAnalyzerWithPrefixTest.php
+++ b/tests/Unit/RouteAnalyzerWithPrefixTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace LaravelSpectrum\Tests\Unit;
+
+use Illuminate\Support\Facades\Route;
+use LaravelSpectrum\Analyzers\RouteAnalyzer;
+use LaravelSpectrum\Cache\DocumentationCache;
+use LaravelSpectrum\Tests\Fixtures\Controllers\PostController;
+use LaravelSpectrum\Tests\Fixtures\Controllers\UserController;
+use LaravelSpectrum\Tests\TestCase;
+
+class RouteAnalyzerWithPrefixTest extends TestCase
+{
+    protected RouteAnalyzer $analyzer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create a mock cache that always calls the callback
+        $cache = $this->createMock(DocumentationCache::class);
+        $cache->method('rememberRoutes')
+            ->willReturnCallback(function ($callback) {
+                return $callback();
+            });
+
+        $this->analyzer = new RouteAnalyzer($cache);
+    }
+
+    /** @test */
+    public function it_detects_routes_with_prefix_groups()
+    {
+        // Arrange - Laravel 11スタイルのプレフィックスグループ
+        Route::prefix('api')->group(function () {
+            Route::get('users', [UserController::class, 'index'])->name('api.users.index');
+            Route::post('users', [UserController::class, 'store'])->name('api.users.store');
+            Route::get('users/{user}', [UserController::class, 'show'])->name('api.users.show');
+        });
+
+        // プレフィックスなしのルート（APIではない）
+        Route::get('web/about', function () {
+            return 'about';
+        })->name('web.about');
+
+        // Act
+        $routes = $this->analyzer->analyze();
+
+        // Assert
+        $this->assertCount(3, $routes, 'Should detect 3 API routes');
+
+        // 全てのルートがapi/プレフィックスを含むことを確認
+        foreach ($routes as $route) {
+            $this->assertStringStartsWith('api/', $route['uri']);
+        }
+
+        // 具体的なルートの確認
+        $this->assertEquals('api/users', $routes[0]['uri']);
+        $this->assertEquals('api/users', $routes[1]['uri']);
+        $this->assertEquals('api/users/{user}', $routes[2]['uri']);
+    }
+
+    /** @test */
+    public function it_detects_nested_prefix_groups()
+    {
+        // Arrange - ネストされたプレフィックスグループ
+        Route::prefix('api')->group(function () {
+            Route::prefix('v1')->group(function () {
+                Route::get('users', [UserController::class, 'index'])->name('api.v1.users.index');
+                Route::prefix('admin')->group(function () {
+                    Route::get('users', [UserController::class, 'index'])->name('api.v1.admin.users.index');
+                });
+            });
+
+            Route::prefix('v2')->group(function () {
+                Route::get('users', [UserController::class, 'index'])->name('api.v2.users.index');
+            });
+        });
+
+        // Act
+        $routes = $this->analyzer->analyze();
+
+        // Assert
+        $this->assertCount(3, $routes);
+        $this->assertEquals('api/v1/users', $routes[0]['uri']);
+        $this->assertEquals('api/v1/admin/users', $routes[1]['uri']);
+        $this->assertEquals('api/v2/users', $routes[2]['uri']);
+    }
+
+    /** @test */
+    public function it_respects_custom_route_patterns_with_prefix()
+    {
+        // Arrange
+        config(['spectrum.route_patterns' => ['api/v2/*']]);
+
+        Route::prefix('api')->group(function () {
+            Route::prefix('v1')->group(function () {
+                Route::get('users', [UserController::class, 'index']);
+            });
+            Route::prefix('v2')->group(function () {
+                Route::get('users', [UserController::class, 'index']);
+                Route::get('posts', [PostController::class, 'index']);
+            });
+        });
+
+        // Act
+        $routes = $this->analyzer->analyze();
+
+        // Assert
+        $this->assertCount(2, $routes);
+        $this->assertEquals('api/v2/users', $routes[0]['uri']);
+        $this->assertEquals('api/v2/posts', $routes[1]['uri']);
+    }
+
+    /** @test */
+    public function it_handles_laravel_11_style_api_routing()
+    {
+        // Arrange - Laravel 11のwithRouting設定をシミュレート
+        // 実際のLaravel 11では、bootstrap/app.phpでapiPrefix: 'api'が設定されるが、
+        // テストでは手動でプレフィックスを追加
+        Route::prefix('api')->middleware('api')->group(function () {
+            Route::apiResource('users', UserController::class);
+        });
+
+        // Act
+        $routes = $this->analyzer->analyze();
+
+        // Assert
+        $this->assertGreaterThanOrEqual(4, count($routes)); // index, store, show, update, destroy
+
+        $expectedRoutes = [
+            'api/users',           // index, store
+            'api/users/{user}',    // show, update, destroy
+        ];
+
+        $actualUris = array_unique(array_column($routes, 'uri'));
+        foreach ($expectedRoutes as $expectedUri) {
+            $this->assertContains($expectedUri, $actualUris);
+        }
+    }
+}


### PR DESCRIPTION
# 概要

SchemaGeneratorでリソース構造から生成する際、exampleキーが存在しない場合にエラーが発生する問題を修正しました。

## 変更内容

リソース構造を処理する際のエラーを修正し、関連する改善を実施しました。

- SchemaGeneratorでexampleキーの存在チェックを追加し、存在する場合のみスキーマに含めるように修正
- READMEのcomposer requireコマンドに--devフラグを追加（開発依存としてインストールすることを明記）
- ルートプレフィックスのテストケースを追加

## 関連情報

demoプロジェクトでgenerateコマンド実行時に発生したエラーの修正対応です。