### PR TITLE
New Feature: OpenAPIタグ生成機能の改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,19 @@ return [
         ],
     ],
     
+    // Tag Mappings for Organizing Endpoints
+    'tags' => [
+        // Exact match
+        'api/v1/auth/login' => 'Authentication',
+        'api/v1/auth/logout' => 'Authentication',
+        
+        // Wildcard patterns
+        'api/v1/auth/*' => 'Authentication',
+        'api/v1/admin/*' => 'Administration',
+        'api/v1/billing/*' => 'Billing',
+        'api/v1/users/*' => 'User Management',
+    ],
+    
     // Cache Configuration
     'cache' => [
         'enabled' => env('SPECTRUM_CACHE_ENABLED', true),
@@ -339,6 +352,32 @@ return [
     'json' => ['type' => 'object'],
     'uuid' => ['type' => 'string', 'format' => 'uuid'],
     'decimal' => ['type' => 'number', 'format' => 'float'],
+],
+```
+
+### Automatic Tag Generation
+
+Laravel Spectrum automatically generates tags for your API endpoints to keep them organized:
+
+- **Automatic extraction**: Tags are extracted from URL paths (e.g., `/api/posts/{post}` → `Post`)
+- **Multi-level support**: Nested resources generate multiple tags (e.g., `/api/posts/{post}/comments` → `['Post', 'Comment']`)
+- **Parameter removal**: Route parameters like `{post}` are automatically cleaned up
+- **Controller fallback**: When URLs are generic, the controller name is used as a fallback
+- **Custom mappings**: Override automatic tags using configuration
+
+```php
+// config/spectrum.php
+'tags' => [
+    // Group all authentication endpoints
+    'api/v1/auth/*' => 'Authentication',
+    
+    // Specific endpoint mapping
+    'api/v1/users/profile' => 'User Profile',
+    
+    // Multiple endpoints to same tag
+    'api/v1/orders/*' => 'Orders',
+    'api/v1/invoices/*' => 'Billing',
+    'api/v1/payments/*' => 'Billing',
 ],
 ```
 

--- a/config/spectrum.php
+++ b/config/spectrum.php
@@ -72,7 +72,7 @@ return [
     'tags' => [
         // Exact match example:
         // 'api/v1/auth/login' => 'Authentication',
-        
+
         // Wildcard example:
         // 'api/v1/auth/*' => 'Authentication',
         // 'api/v1/admin/*' => 'Administration',

--- a/config/spectrum.php
+++ b/config/spectrum.php
@@ -62,6 +62,25 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Tag Mappings
+    |--------------------------------------------------------------------------
+    |
+    | Custom tag mappings for organizing your API endpoints. You can use
+    | exact matches or wildcards (*) to map routes to specific tags.
+    |
+    */
+    'tags' => [
+        // Exact match example:
+        // 'api/v1/auth/login' => 'Authentication',
+        
+        // Wildcard example:
+        // 'api/v1/auth/*' => 'Authentication',
+        // 'api/v1/admin/*' => 'Administration',
+        // 'api/v1/billing/*' => 'Billing',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Authentication Configuration
     |--------------------------------------------------------------------------
     |

--- a/src/Generators/OpenApiGenerator.php
+++ b/src/Generators/OpenApiGenerator.php
@@ -326,13 +326,56 @@ class OpenApiGenerator
      */
     protected function generateTags(array $route): array
     {
+        // 設定ファイルからカスタムマッピングを取得
+        $customMappings = config('spectrum.tags', []);
+        
+        // 完全一致のマッピングをチェック
+        if (isset($customMappings[$route['uri']])) {
+            return (array) $customMappings[$route['uri']];
+        }
+        
+        // ワイルドカードマッピングをチェック
+        foreach ($customMappings as $pattern => $tag) {
+            if (Str::is($pattern, $route['uri'])) {
+                return (array) $tag;
+            }
+        }
+        
+        // URIからセグメントを取得
         $segments = explode('/', trim($route['uri'], '/'));
-
-        // 'api/v1/users' -> 'Users'
-        $tag = end($segments);
-        $tag = Str::studly(Str::singular($tag));
-
-        return [$tag];
+        $tags = [];
+        
+        // 一般的なプレフィックスを除外
+        $ignorePrefixes = ['api', 'v1', 'v2', 'v3'];
+        $segments = array_values(array_filter($segments, function ($segment) use ($ignorePrefixes) {
+            return !in_array($segment, $ignorePrefixes);
+        }));
+        
+        // セグメントからタグを生成
+        foreach ($segments as $segment) {
+            // パラメータ（{param}形式）を除外
+            if (preg_match('/^\{[^}]+\}$/', $segment)) {
+                continue;
+            }
+            
+            // パラメータを含むセグメントから名前部分を抽出
+            $cleanSegment = preg_replace('/\{[^}]+\}/', '', $segment);
+            if (!empty($cleanSegment)) {
+                $tags[] = Str::studly(Str::singular($cleanSegment));
+            }
+        }
+        
+        // タグが空の場合、コントローラー名をフォールバックとして使用
+        if (empty($tags) && isset($route['controller'])) {
+            $controllerName = class_basename($route['controller']);
+            $controllerName = str_replace('Controller', '', $controllerName);
+            if (!empty($controllerName)) {
+                $tags[] = Str::studly(Str::singular($controllerName));
+            }
+        }
+        
+        // 重複を除去して返す
+        return array_values(array_unique($tags));
     }
 
     /**

--- a/src/Generators/OpenApiGenerator.php
+++ b/src/Generators/OpenApiGenerator.php
@@ -328,52 +328,52 @@ class OpenApiGenerator
     {
         // 設定ファイルからカスタムマッピングを取得
         $customMappings = config('spectrum.tags', []);
-        
+
         // 完全一致のマッピングをチェック
         if (isset($customMappings[$route['uri']])) {
             return (array) $customMappings[$route['uri']];
         }
-        
+
         // ワイルドカードマッピングをチェック
         foreach ($customMappings as $pattern => $tag) {
             if (Str::is($pattern, $route['uri'])) {
                 return (array) $tag;
             }
         }
-        
+
         // URIからセグメントを取得
         $segments = explode('/', trim($route['uri'], '/'));
         $tags = [];
-        
+
         // 一般的なプレフィックスを除外
         $ignorePrefixes = ['api', 'v1', 'v2', 'v3'];
         $segments = array_values(array_filter($segments, function ($segment) use ($ignorePrefixes) {
-            return !in_array($segment, $ignorePrefixes);
+            return ! in_array($segment, $ignorePrefixes);
         }));
-        
+
         // セグメントからタグを生成
         foreach ($segments as $segment) {
             // パラメータ（{param}形式）を除外
             if (preg_match('/^\{[^}]+\}$/', $segment)) {
                 continue;
             }
-            
+
             // パラメータを含むセグメントから名前部分を抽出
             $cleanSegment = preg_replace('/\{[^}]+\}/', '', $segment);
-            if (!empty($cleanSegment)) {
+            if (! empty($cleanSegment)) {
                 $tags[] = Str::studly(Str::singular($cleanSegment));
             }
         }
-        
+
         // タグが空の場合、コントローラー名をフォールバックとして使用
         if (empty($tags) && isset($route['controller'])) {
             $controllerName = class_basename($route['controller']);
             $controllerName = str_replace('Controller', '', $controllerName);
-            if (!empty($controllerName)) {
+            if (! empty($controllerName)) {
                 $tags[] = Str::studly(Str::singular($controllerName));
             }
         }
-        
+
         // 重複を除去して返す
         return array_values(array_unique($tags));
     }

--- a/tests/Unit/Generators/OpenApiGeneratorTagsTest.php
+++ b/tests/Unit/Generators/OpenApiGeneratorTagsTest.php
@@ -2,14 +2,14 @@
 
 namespace Tests\Unit\Generators;
 
-use LaravelSpectrum\Generators\OpenApiGenerator;
-use LaravelSpectrum\Analyzers\FormRequestAnalyzer;
-use LaravelSpectrum\Analyzers\ResourceAnalyzer;
-use LaravelSpectrum\Analyzers\ControllerAnalyzer;
-use LaravelSpectrum\Analyzers\InlineValidationAnalyzer;
-use LaravelSpectrum\Generators\SchemaGenerator;
-use LaravelSpectrum\Generators\ErrorResponseGenerator;
 use LaravelSpectrum\Analyzers\AuthenticationAnalyzer;
+use LaravelSpectrum\Analyzers\ControllerAnalyzer;
+use LaravelSpectrum\Analyzers\FormRequestAnalyzer;
+use LaravelSpectrum\Analyzers\InlineValidationAnalyzer;
+use LaravelSpectrum\Analyzers\ResourceAnalyzer;
+use LaravelSpectrum\Generators\ErrorResponseGenerator;
+use LaravelSpectrum\Generators\OpenApiGenerator;
+use LaravelSpectrum\Generators\SchemaGenerator;
 use LaravelSpectrum\Generators\SecuritySchemeGenerator;
 use LaravelSpectrum\Tests\TestCase;
 use Mockery;
@@ -18,13 +18,21 @@ use ReflectionClass;
 class OpenApiGeneratorTagsTest extends TestCase
 {
     protected OpenApiGenerator $generator;
+
     protected $mockFormRequestAnalyzer;
+
     protected $mockResourceAnalyzer;
+
     protected $mockControllerAnalyzer;
+
     protected $mockInlineValidationAnalyzer;
+
     protected $mockSchemaGenerator;
+
     protected $mockErrorResponseGenerator;
+
     protected $mockAuthenticationAnalyzer;
+
     protected $mockSecuritySchemeGenerator;
 
     protected function setUp(): void
@@ -68,7 +76,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         ];
 
         $tags = $this->callProtectedMethod($this->generator, 'generateTags', [$route]);
-        
+
         $this->assertEquals(['Post'], $tags);
     }
 
@@ -82,7 +90,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         ];
 
         $tags = $this->callProtectedMethod($this->generator, 'generateTags', [$route]);
-        
+
         $this->assertEquals(['Post', 'Comment'], $tags);
     }
 
@@ -96,7 +104,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         ];
 
         $tags = $this->callProtectedMethod($this->generator, 'generateTags', [$route]);
-        
+
         $this->assertEquals(['User'], $tags);
     }
 
@@ -106,7 +114,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         // テスト用の設定値をセット
         $this->app['config']->set('spectrum.tags', [
             'api/v1/auth/*' => 'Authentication',
-            'api/v1/admin/*' => 'Administration'
+            'api/v1/admin/*' => 'Administration',
         ]);
 
         $route = [
@@ -116,7 +124,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         ];
 
         $tags = $this->callProtectedMethod($this->generator, 'generateTags', [$route]);
-        
+
         $this->assertEquals(['Authentication'], $tags);
     }
 
@@ -130,7 +138,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         ];
 
         $tags = $this->callProtectedMethod($this->generator, 'generateTags', [$route]);
-        
+
         $this->assertEquals(['Post', 'Comment', 'Like'], $tags);
     }
 
@@ -144,7 +152,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         ];
 
         $tags = $this->callProtectedMethod($this->generator, 'generateTags', [$route]);
-        
+
         $this->assertEquals(['User'], $tags);
     }
 
@@ -158,7 +166,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         ];
 
         $tags = $this->callProtectedMethod($this->generator, 'generateTags', [$route]);
-        
+
         $this->assertEquals(['User'], $tags);
     }
 
@@ -172,7 +180,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         ];
 
         $tags = $this->callProtectedMethod($this->generator, 'generateTags', [$route]);
-        
+
         $this->assertEquals(['Post'], $tags);
     }
 
@@ -191,7 +199,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         ];
 
         $tags = $this->callProtectedMethod($this->generator, 'generateTags', [$route]);
-        
+
         $this->assertEquals(['Authentication'], $tags);
     }
 
@@ -200,6 +208,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         $reflection = new ReflectionClass($object);
         $method = $reflection->getMethod($methodName);
         $method->setAccessible(true);
+
         return $method->invokeArgs($object, $parameters);
     }
 }

--- a/tests/Unit/Generators/OpenApiGeneratorTagsTest.php
+++ b/tests/Unit/Generators/OpenApiGeneratorTagsTest.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Tests\Unit\Generators;
+
+use LaravelSpectrum\Generators\OpenApiGenerator;
+use LaravelSpectrum\Analyzers\FormRequestAnalyzer;
+use LaravelSpectrum\Analyzers\ResourceAnalyzer;
+use LaravelSpectrum\Analyzers\ControllerAnalyzer;
+use LaravelSpectrum\Analyzers\InlineValidationAnalyzer;
+use LaravelSpectrum\Generators\SchemaGenerator;
+use LaravelSpectrum\Generators\ErrorResponseGenerator;
+use LaravelSpectrum\Analyzers\AuthenticationAnalyzer;
+use LaravelSpectrum\Generators\SecuritySchemeGenerator;
+use LaravelSpectrum\Tests\TestCase;
+use Mockery;
+use ReflectionClass;
+
+class OpenApiGeneratorTagsTest extends TestCase
+{
+    protected OpenApiGenerator $generator;
+    protected $mockFormRequestAnalyzer;
+    protected $mockResourceAnalyzer;
+    protected $mockControllerAnalyzer;
+    protected $mockInlineValidationAnalyzer;
+    protected $mockSchemaGenerator;
+    protected $mockErrorResponseGenerator;
+    protected $mockAuthenticationAnalyzer;
+    protected $mockSecuritySchemeGenerator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockFormRequestAnalyzer = Mockery::mock(FormRequestAnalyzer::class);
+        $this->mockResourceAnalyzer = Mockery::mock(ResourceAnalyzer::class);
+        $this->mockControllerAnalyzer = Mockery::mock(ControllerAnalyzer::class);
+        $this->mockInlineValidationAnalyzer = Mockery::mock(InlineValidationAnalyzer::class);
+        $this->mockSchemaGenerator = Mockery::mock(SchemaGenerator::class);
+        $this->mockErrorResponseGenerator = Mockery::mock(ErrorResponseGenerator::class);
+        $this->mockAuthenticationAnalyzer = Mockery::mock(AuthenticationAnalyzer::class);
+        $this->mockSecuritySchemeGenerator = Mockery::mock(SecuritySchemeGenerator::class);
+
+        $this->generator = new OpenApiGenerator(
+            $this->mockFormRequestAnalyzer,
+            $this->mockResourceAnalyzer,
+            $this->mockControllerAnalyzer,
+            $this->mockInlineValidationAnalyzer,
+            $this->mockSchemaGenerator,
+            $this->mockErrorResponseGenerator,
+            $this->mockAuthenticationAnalyzer,
+            $this->mockSecuritySchemeGenerator
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_removes_parameters_from_tags()
+    {
+        $route = [
+            'uri' => 'api/v1/posts/{post}',
+            'controller' => 'PostController',
+            'method' => 'show',
+        ];
+
+        $tags = $this->callProtectedMethod($this->generator, 'generateTags', [$route]);
+        
+        $this->assertEquals(['Post'], $tags);
+    }
+
+    /** @test */
+    public function it_handles_nested_resources_with_multiple_tags()
+    {
+        $route = [
+            'uri' => 'api/v1/posts/{post}/comments',
+            'controller' => 'CommentController',
+            'method' => 'index',
+        ];
+
+        $tags = $this->callProtectedMethod($this->generator, 'generateTags', [$route]);
+        
+        $this->assertEquals(['Post', 'Comment'], $tags);
+    }
+
+    /** @test */
+    public function it_uses_controller_name_as_fallback_for_generic_paths()
+    {
+        $route = [
+            'uri' => 'api/v1/{resource}',
+            'controller' => 'UserController',
+            'method' => 'index',
+        ];
+
+        $tags = $this->callProtectedMethod($this->generator, 'generateTags', [$route]);
+        
+        $this->assertEquals(['User'], $tags);
+    }
+
+    /** @test */
+    public function it_respects_custom_tag_mappings_from_config()
+    {
+        // テスト用の設定値をセット
+        $this->app['config']->set('spectrum.tags', [
+            'api/v1/auth/*' => 'Authentication',
+            'api/v1/admin/*' => 'Administration'
+        ]);
+
+        $route = [
+            'uri' => 'api/v1/auth/login',
+            'controller' => 'AuthController',
+            'method' => 'login',
+        ];
+
+        $tags = $this->callProtectedMethod($this->generator, 'generateTags', [$route]);
+        
+        $this->assertEquals(['Authentication'], $tags);
+    }
+
+    /** @test */
+    public function it_handles_deeply_nested_resources()
+    {
+        $route = [
+            'uri' => 'api/v1/posts/{post}/comments/{comment}/likes',
+            'controller' => 'LikeController',
+            'method' => 'index',
+        ];
+
+        $tags = $this->callProtectedMethod($this->generator, 'generateTags', [$route]);
+        
+        $this->assertEquals(['Post', 'Comment', 'Like'], $tags);
+    }
+
+    /** @test */
+    public function it_handles_simple_resource_paths()
+    {
+        $route = [
+            'uri' => 'api/users',
+            'controller' => 'UserController',
+            'method' => 'index',
+        ];
+
+        $tags = $this->callProtectedMethod($this->generator, 'generateTags', [$route]);
+        
+        $this->assertEquals(['User'], $tags);
+    }
+
+    /** @test */
+    public function it_ignores_common_prefixes()
+    {
+        $route = [
+            'uri' => 'api/v1/users',
+            'controller' => 'UserController',
+            'method' => 'index',
+        ];
+
+        $tags = $this->callProtectedMethod($this->generator, 'generateTags', [$route]);
+        
+        $this->assertEquals(['User'], $tags);
+    }
+
+    /** @test */
+    public function it_handles_optional_parameters()
+    {
+        $route = [
+            'uri' => 'api/posts/{post?}',
+            'controller' => 'PostController',
+            'method' => 'show',
+        ];
+
+        $tags = $this->callProtectedMethod($this->generator, 'generateTags', [$route]);
+        
+        $this->assertEquals(['Post'], $tags);
+    }
+
+    /** @test */
+    public function it_handles_custom_tag_mapping_with_exact_match()
+    {
+        $this->app['config']->set('spectrum.tags', [
+            'api/v1/auth/login' => 'Authentication',
+            'api/v1/auth/logout' => 'Authentication',
+        ]);
+
+        $route = [
+            'uri' => 'api/v1/auth/login',
+            'controller' => 'AuthController',
+            'method' => 'login',
+        ];
+
+        $tags = $this->callProtectedMethod($this->generator, 'generateTags', [$route]);
+        
+        $this->assertEquals(['Authentication'], $tags);
+    }
+
+    protected function callProtectedMethod($object, $methodName, array $parameters = [])
+    {
+        $reflection = new ReflectionClass($object);
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+        return $method->invokeArgs($object, $parameters);
+    }
+}


### PR DESCRIPTION
# 概要

OpenAPIドキュメントのタグ生成ロジックを改善し、より適切なタグが自動生成されるようにしました。

## 変更内容

現在のタグ生成では、URLパスの末尾（例：`{post}`）がそのままタグとして使用される問題がありました。これを改善し、以下の機能を実装しました：

- パラメータ（`{param}`形式）を自動的に除外し、リソース名のみを抽出
- 複数階層のリソース（`/posts/{post}/comments`）から複数のタグ（`['Post', 'Comment']`）を生成
- URLが汎用的な場合はコントローラー名をフォールバックとして使用
- 設定ファイルでカスタムタグマッピングを定義可能（ワイルドカードもサポート）
- 一般的なプレフィックス（`api`, `v1`, `v2`等）を自動的に除外

## 関連情報

- Zero-annotationの原則を維持しながら、柔軟なタグ管理を実現
- `config/spectrum.php`でタグマッピングをカスタマイズ可能