### PR TITLE
Bugfix: Swagger UI v5でStandaloneLayoutエラーを修正

### DIFF
--- a/resources/views/live-preview.blade.php
+++ b/resources/views/live-preview.blade.php
@@ -68,12 +68,11 @@
                 deepLinking: true,
                 presets: [
                     SwaggerUIBundle.presets.apis,
-                    SwaggerUIBundle.SwaggerUIStandalonePreset
+                    SwaggerUIStandalonePreset
                 ],
                 plugins: [
                     SwaggerUIBundle.plugins.DownloadUrl
-                ],
-                layout: "StandaloneLayout"
+                ]
             });
         }
         

--- a/src/Services/LiveReloadServer.php
+++ b/src/Services/LiveReloadServer.php
@@ -171,12 +171,11 @@ class LiveReloadServer
                 deepLinking: true,
                 presets: [
                     SwaggerUIBundle.presets.apis,
-                    SwaggerUIBundle.SwaggerUIStandalonePreset
+                    SwaggerUIStandalonePreset
                 ],
                 plugins: [
                     SwaggerUIBundle.plugins.DownloadUrl
-                ],
-                layout: "StandaloneLayout"
+                ]
             });
         }
         


### PR DESCRIPTION
# 概要

`php artisan spectrum:watch`実行時に発生する「No layout defined for "StandaloneLayout"」エラーを修正しました。

## 変更内容

Swagger UI v5での破壊的変更に対応するため、以下の修正を行いました：

- `SwaggerUIBundle.SwaggerUIStandalonePreset`を`SwaggerUIStandalonePreset`に変更
- 不要な`layout: "StandaloneLayout"`設定を削除
- live-preview.blade.phpとLiveReloadServer.phpの両方で同様の修正を実施

## 関連情報

- Swagger UI v5では`SwaggerUIStandalonePreset`がグローバルスコープに直接エクスポートされるように変更されました