### PR TITLE
Bugfix: WebSocket通知が送信されない問題を修正

### DIFF
--- a/src/Console/WatchCommand.php
+++ b/src/Console/WatchCommand.php
@@ -168,7 +168,9 @@ class WatchCommand extends Command
             $notificationData['forceReload'] = true;
         }
 
+        $this->info('  📡 Sending WebSocket notification...');
         $this->server->notifyClients($notificationData);
+        $this->info('  ✅ WebSocket notification sent');
     }
 
     protected function runGenerateCommand(array $options = []): int

--- a/src/Services/LiveReloadServer.php
+++ b/src/Services/LiveReloadServer.php
@@ -22,6 +22,14 @@ class LiveReloadServer
         }
     }
 
+    /**
+     * Reset clients for testing purposes
+     */
+    public static function resetClients(): void
+    {
+        self::$clients = new \SplObjectStorage;
+    }
+
     public function start(string $host, int $port): void
     {
         // Start HTTP server for Swagger UI

--- a/src/Services/LiveReloadServer.php
+++ b/src/Services/LiveReloadServer.php
@@ -9,7 +9,7 @@ use Workerman\Worker;
 
 class LiveReloadServer
 {
-    protected $clients;
+    protected static $clients;
 
     protected $httpWorker;
 
@@ -17,7 +17,9 @@ class LiveReloadServer
 
     public function __construct()
     {
-        $this->clients = new \SplObjectStorage;
+        if (! self::$clients) {
+            self::$clients = new \SplObjectStorage;
+        }
     }
 
     public function start(string $host, int $port): void
@@ -102,9 +104,10 @@ class LiveReloadServer
         $this->wsWorker->count = 1;
 
         $this->wsWorker->onConnect = function (TcpConnection $connection) {
-            $this->clients->attach($connection);
+            self::$clients->attach($connection);
             $resourceId = spl_object_id($connection);
-            echo "New connection! ({$resourceId})\n";
+            $clientCount = count(self::$clients);
+            echo "New connection! ({$resourceId}) - Total clients: {$clientCount}\n";
         };
 
         $this->wsWorker->onMessage = function (TcpConnection $connection, $data) {
@@ -112,9 +115,10 @@ class LiveReloadServer
         };
 
         $this->wsWorker->onClose = function (TcpConnection $connection) {
-            $this->clients->detach($connection);
+            self::$clients->detach($connection);
             $resourceId = spl_object_id($connection);
-            echo "Connection {$resourceId} has disconnected\n";
+            $clientCount = count(self::$clients);
+            echo "Connection {$resourceId} has disconnected - Remaining clients: {$clientCount}\n";
         };
 
         $this->wsWorker->onError = function (TcpConnection $connection, $code, $msg) {
@@ -125,9 +129,17 @@ class LiveReloadServer
     public function notifyClients(array $data): void
     {
         $message = json_encode($data);
+        $clientCount = count(self::$clients);
 
-        foreach ($this->clients as $client) {
-            $client->send($message);
+        echo "[LiveReloadServer] Notifying {$clientCount} clients with message: {$message}\n";
+
+        foreach (self::$clients as $client) {
+            try {
+                $client->send($message);
+                echo "[LiveReloadServer] Message sent to client\n";
+            } catch (\Exception $e) {
+                echo "[LiveReloadServer] Failed to send message: {$e->getMessage()}\n";
+            }
         }
     }
 

--- a/tests/Unit/Services/LiveReloadServerTest.php
+++ b/tests/Unit/Services/LiveReloadServerTest.php
@@ -12,6 +12,7 @@ class LiveReloadServerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+        LiveReloadServer::resetClients();
         $this->server = new LiveReloadServer;
     }
 
@@ -108,11 +109,11 @@ class LiveReloadServerTest extends TestCase
 
     public function test_clients_storage_initialization(): void
     {
-        $reflection = new \ReflectionClass($this->server);
+        $reflection = new \ReflectionClass(LiveReloadServer::class);
         $clientsProperty = $reflection->getProperty('clients');
         $clientsProperty->setAccessible(true);
 
-        $clients = $clientsProperty->getValue($this->server);
+        $clients = $clientsProperty->getValue(null);
 
         $this->assertInstanceOf(\SplObjectStorage::class, $clients);
         $this->assertEquals(0, $clients->count());


### PR DESCRIPTION
# 概要

`spectrum:watch`コマンドでファイル変更時にWebSocket通知が送信されず、自動リロードが機能しない問題を修正しました。

## 変更内容

Workermanの複数ワーカー間でクライアントリストが共有されていなかった問題を解決しました。

- `LiveReloadServer`のクライアントリストを静的変数に変更し、ワーカー間で共有可能に
- デバッグログを追加して問題の診断を容易に
  - WebSocket接続/切断時にクライアント数を表示
  - `notifyClients`メソッドに詳細なログを追加
  - `WatchCommand`にWebSocket通知送信のログを追加
- これにより、ファイル変更時の自動ブラウザリロード機能が正常に動作するように

### 技術的詳細
- Workermanでは各ワーカーが独立したプロセスとして動作するため、インスタンス変数は共有されない
- 静的変数を使用することで、同一PHPプロセス内でのデータ共有を実現

## 関連情報

- #54 で追加した自動リロード機能が動作しない問題の修正
- #52 の子プロセス実行の修正後に発生した問題