### PR TITLE
Bugfix: 自動リロード時のURLクエリパラメータ累積問題を修正

### DIFF
--- a/resources/views/live-preview.blade.php
+++ b/resources/views/live-preview.blade.php
@@ -114,8 +114,11 @@
                 // Auto reload page
                 setTimeout(() => {
                     console.log('Reloading page now...');
-                    // Force reload with cache bypass
-                    window.location.href = window.location.href + '?t=' + new Date().getTime();
+                    // Remove existing query parameters and add new timestamp
+                    const url = new URL(window.location.href);
+                    url.search = ''; // Clear all query parameters
+                    url.searchParams.set('t', new Date().getTime().toString());
+                    window.location.href = url.href;
                 }, 500);
             }
         };


### PR DESCRIPTION
# 概要

`spectrum:watch`の自動リロード機能で、ページリロードのたびにURLクエリパラメータが累積してしまう問題を修正しました。

## 変更内容

ファイル変更時の自動リロードで、キャッシュバスティング用のタイムスタンプパラメータが累積する問題を解決しました。

- **修正前**: `http://localhost:8080/?t=1234&t=5678&t=9012...` のように累積
- **修正後**: `http://localhost:8080/?t=1234` のように常に1つのパラメータのみ

### 技術的詳細
- `URL` APIを使用して既存のクエリパラメータをクリア
- 新しいタイムスタンプパラメータのみを設定
- `getTime()`の戻り値を文字列に変換してTypeScriptの型エラーも解消

### 修正ファイル
- `resources/views/live-preview.blade.php` - Laravelビューテンプレート
- `src/Services/LiveReloadServer.php` - 埋め込みHTMLテンプレート

## 関連情報

- #54 で追加した自動リロード機能の改善
- #56 でWebSocket通知の問題を修正した後に発見された問題