### PR TITLE
New Feature: request()->validate() と ->validate() パターンの検出機能を追加

### DIFF
--- a/demo-app/laravel-app/app/Http/Controllers/RequestValidateController.php
+++ b/demo-app/laravel-app/app/Http/Controllers/RequestValidateController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class RequestValidateController extends Controller
+{
+    /**
+     * Store a new blog post using request()->validate()
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function store(Request $request)
+    {
+        $validated = request()->validate([
+            'title' => 'required|string|max:255',
+            'content' => 'required|string|min:10',
+            'author' => 'required|string|max:100',
+            'published' => 'required|boolean',
+            'tags' => 'array|max:5',
+            'tags.*' => 'string|max:50',
+        ], [
+            'title.required' => 'The blog title is required.',
+            'content.required' => 'The blog content is required.',
+            'content.min' => 'The blog content must be at least 10 characters.',
+        ], [
+            'title' => 'Blog Title',
+            'content' => 'Blog Content',
+            'author' => 'Author Name',
+        ]);
+
+        return response()->json([
+            'message' => 'Blog post created successfully',
+            'data' => $validated,
+        ], 201);
+    }
+
+    /**
+     * Upload files using request()->validate()
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function upload(Request $request)
+    {
+        $validated = request()->validate([
+            'avatar' => 'required|image|mimes:jpeg,png,jpg|max:2048',
+            'resume' => 'nullable|file|mimes:pdf,doc,docx|max:5120',
+            'portfolio' => 'nullable|url',
+        ]);
+
+        return response()->json([
+            'message' => 'Files uploaded successfully',
+            'uploaded' => array_keys($validated),
+        ]);
+    }
+
+    /**
+     * Update user profile with mixed validation
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function update(Request $request, $id)
+    {
+        // First validate the user ID
+        $this->validate($request, [
+            'user_id' => 'required|integer|exists:users,id',
+        ]);
+
+        // Then validate the profile data using request()->validate()
+        $profileData = request()->validate([
+            'name' => 'sometimes|string|max:255',
+            'email' => 'sometimes|email|unique:users,email,'.$id,
+            'bio' => 'nullable|string|max:500',
+            'website' => 'nullable|url',
+            'profile_image' => 'sometimes|image|max:1024',
+        ]);
+
+        return response()->json([
+            'message' => 'Profile updated successfully',
+            'updated_fields' => array_keys($profileData),
+        ]);
+    }
+}

--- a/demo-app/laravel-app/app/Http/Controllers/RequestValidateController.php
+++ b/demo-app/laravel-app/app/Http/Controllers/RequestValidateController.php
@@ -7,6 +7,30 @@ use Illuminate\Http\Request;
 class RequestValidateController extends Controller
 {
     /**
+     * Store a new blog post using $request->validate()
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function storeWithRequestVariable(Request $request)
+    {
+        $validated = $request->validate([
+            'title' => 'required|string|max:255',
+            'slug' => 'required|string|unique:posts',
+            'content' => 'required|string|min:50',
+            'category' => 'required|string|in:tech,business,lifestyle',
+            'featured_image' => 'nullable|image|max:2048',
+        ], [
+            'content.min' => 'The article content must be at least 50 characters long.',
+            'featured_image.max' => 'The featured image must not exceed 2MB.',
+        ]);
+
+        return response()->json([
+            'message' => 'Article created successfully',
+            'data' => $validated,
+        ], 201);
+    }
+
+    /**
      * Store a new blog post using request()->validate()
      *
      * @return \Illuminate\Http\JsonResponse
@@ -80,6 +104,25 @@ class RequestValidateController extends Controller
         return response()->json([
             'message' => 'Profile updated successfully',
             'updated_fields' => array_keys($profileData),
+        ]);
+    }
+
+    /**
+     * Test different request variable names with $req->validate()
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function testDifferentVariableNames(Request $req)
+    {
+        $validated = $req->validate([
+            'setting_name' => 'required|string|max:50',
+            'setting_value' => 'required|string',
+            'is_active' => 'required|boolean',
+        ]);
+
+        return response()->json([
+            'message' => 'Settings saved',
+            'data' => $validated,
         ]);
     }
 }

--- a/demo-app/laravel-app/routes/api.php
+++ b/demo-app/laravel-app/routes/api.php
@@ -48,6 +48,8 @@ use App\Http\Controllers\RequestValidateController;
 
 Route::prefix('request-validate')->group(function () {
     Route::post('/blog/posts', [RequestValidateController::class, 'store']);
+    Route::post('/blog/articles', [RequestValidateController::class, 'storeWithRequestVariable']);
     Route::post('/user/upload', [RequestValidateController::class, 'upload']);
     Route::put('/user/profile/{id}', [RequestValidateController::class, 'update']);
+    Route::post('/settings', [RequestValidateController::class, 'testDifferentVariableNames']);
 });

--- a/demo-app/laravel-app/routes/api.php
+++ b/demo-app/laravel-app/routes/api.php
@@ -42,3 +42,12 @@ Route::prefix('uploads')->group(function () {
     Route::post('/profile', [FileUploadController::class, 'upload']);
     Route::post('/images', [FileUploadController::class, 'uploadImages']);
 });
+
+// Request validate routes - request()->validate() pattern test
+use App\Http\Controllers\RequestValidateController;
+
+Route::prefix('request-validate')->group(function () {
+    Route::post('/blog/posts', [RequestValidateController::class, 'store']);
+    Route::post('/user/upload', [RequestValidateController::class, 'upload']);
+    Route::put('/user/profile/{id}', [RequestValidateController::class, 'update']);
+});

--- a/src/Analyzers/InlineValidationAnalyzer.php
+++ b/src/Analyzers/InlineValidationAnalyzer.php
@@ -60,6 +60,18 @@ class InlineValidationAnalyzer
                     return null;
                 }
 
+                // $request->validate() の呼び出しを検出 (変数経由)
+                if ($node instanceof Node\Expr\MethodCall &&
+                    $node->var instanceof Node\Expr\Variable &&
+                    $node->name instanceof Node\Identifier &&
+                    $node->name->name === 'validate' &&
+                    $this->isRequestVariable($node->var)) {
+
+                    $this->extractRequestVariableValidation($node);
+
+                    return null;
+                }
+
                 // Validator::make() の呼び出しも検出
                 if ($node instanceof Node\Expr\StaticCall &&
                     $node->class instanceof Node\Name &&
@@ -127,6 +139,54 @@ class InlineValidationAnalyzer
                 if (! empty($validation['rules'])) {
                     $this->validations[] = $validation;
                 }
+            }
+
+            protected function extractRequestVariableValidation(Node\Expr\MethodCall $node)
+            {
+                if (count($node->args) < 1) {
+                    return;
+                }
+
+                // 第1引数がルール配列
+                $rulesArg = $node->args[0]->value;
+
+                // 第2引数がカスタムメッセージ（オプション）
+                $messagesArg = isset($node->args[1]) ? $node->args[1]->value : null;
+
+                // 第3引数がカスタム属性名（オプション）
+                $attributesArg = isset($node->args[2]) ? $node->args[2]->value : null;
+
+                $validation = [
+                    'type' => 'request_variable_validate',
+                    'rules' => $this->extractRulesArray($rulesArg),
+                    'messages' => $messagesArg ? $this->extractArray($messagesArg) : [],
+                    'attributes' => $attributesArg ? $this->extractArray($attributesArg) : [],
+                ];
+
+                if (! empty($validation['rules'])) {
+                    $this->validations[] = $validation;
+                }
+            }
+
+            /**
+             * 変数がRequestインスタンスかどうかを判定
+             */
+            protected function isRequestVariable(Node\Expr\Variable $var): bool
+            {
+                // 一般的なRequest変数名をチェック
+                $commonRequestVarNames = [
+                    'request', 'req', 'httpRequest', 'r',
+                    'input', 'data', 'requestData',
+                ];
+
+                if (in_array($var->name, $commonRequestVarNames)) {
+                    return true;
+                }
+
+                // TODO: より高度な型推論を実装する場合は、
+                // メソッドの引数の型ヒントをチェックするロジックを追加
+
+                return false;
             }
 
             protected function extractValidatorMake(Node\Expr\StaticCall $node)

--- a/tests/Unit/Analyzers/InlineValidationAnalyzerRequestValidateTest.php
+++ b/tests/Unit/Analyzers/InlineValidationAnalyzerRequestValidateTest.php
@@ -1,0 +1,320 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\Analyzers;
+
+use LaravelSpectrum\Analyzers\InlineValidationAnalyzer;
+use LaravelSpectrum\Support\TypeInference;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
+
+class InlineValidationAnalyzerRequestValidateTest extends TestCase
+{
+    private InlineValidationAnalyzer $analyzer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->analyzer = new InlineValidationAnalyzer(new TypeInference);
+    }
+
+    public function test_analyzes_request_validate_method(): void
+    {
+        $code = <<<'PHP'
+<?php
+class TestController extends Controller
+{
+    public function store(Request $request)
+    {
+        $validated = request()->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:users',
+            'age' => 'required|integer|min:18',
+        ]);
+        
+        return response()->json($validated);
+    }
+}
+PHP;
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse($code);
+
+        $method = $this->findMethod($ast, 'store');
+        $result = $this->analyzer->analyze($method);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('rules', $result);
+        $this->assertArrayHasKey('name', $result['rules']);
+        $this->assertArrayHasKey('email', $result['rules']);
+        $this->assertArrayHasKey('age', $result['rules']);
+        $this->assertEquals('required|string|max:255', $result['rules']['name']);
+        $this->assertEquals('required|email|unique:users', $result['rules']['email']);
+        $this->assertEquals('required|integer|min:18', $result['rules']['age']);
+    }
+
+    public function test_analyzes_request_validate_with_messages(): void
+    {
+        $code = <<<'PHP'
+<?php
+class TestController extends Controller
+{
+    public function update(Request $request)
+    {
+        $validated = request()->validate([
+            'title' => 'required|string|max:100',
+            'content' => 'required|string',
+        ], [
+            'title.required' => 'タイトルは必須です',
+            'content.required' => '内容は必須です',
+        ]);
+        
+        return response()->json($validated);
+    }
+}
+PHP;
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse($code);
+
+        $method = $this->findMethod($ast, 'update');
+        $result = $this->analyzer->analyze($method);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('messages', $result);
+        $this->assertEquals('タイトルは必須です', $result['messages']['title.required']);
+        $this->assertEquals('内容は必須です', $result['messages']['content.required']);
+    }
+
+    public function test_analyzes_request_validate_with_attributes(): void
+    {
+        $code = <<<'PHP'
+<?php
+class TestController extends Controller
+{
+    public function create(Request $request)
+    {
+        $validated = request()->validate([
+            'user_name' => 'required|string',
+            'user_email' => 'required|email',
+        ], [], [
+            'user_name' => 'ユーザー名',
+            'user_email' => 'メールアドレス',
+        ]);
+        
+        return response()->json($validated);
+    }
+}
+PHP;
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse($code);
+
+        $method = $this->findMethod($ast, 'create');
+        $result = $this->analyzer->analyze($method);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('attributes', $result);
+        $this->assertEquals('ユーザー名', $result['attributes']['user_name']);
+        $this->assertEquals('メールアドレス', $result['attributes']['user_email']);
+    }
+
+    public function test_analyzes_request_validate_with_file_upload(): void
+    {
+        $code = <<<'PHP'
+<?php
+class TestController extends Controller
+{
+    public function upload(Request $request)
+    {
+        $validated = request()->validate([
+            'title' => 'required|string|max:255',
+            'photo' => 'required|image|mimes:jpeg,png|max:2048',
+            'document' => 'nullable|file|mimes:pdf,doc,docx|max:10240',
+        ]);
+        
+        return response()->json(['success' => true]);
+    }
+}
+PHP;
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse($code);
+
+        $method = $this->findMethod($ast, 'upload');
+        $result = $this->analyzer->analyze($method);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('rules', $result);
+        $this->assertEquals('required|image|mimes:jpeg,png|max:2048', $result['rules']['photo']);
+        $this->assertEquals('nullable|file|mimes:pdf,doc,docx|max:10240', $result['rules']['document']);
+    }
+
+    public function test_analyzes_multiple_request_validate_calls(): void
+    {
+        $code = <<<'PHP'
+<?php
+class TestController extends Controller
+{
+    public function process(Request $request)
+    {
+        // First validation
+        $step1 = request()->validate([
+            'step' => 'required|integer|in:1,2',
+        ]);
+        
+        if ($step1['step'] === 1) {
+            // Second validation
+            $step1Data = request()->validate([
+                'name' => 'required|string',
+                'email' => 'required|email',
+            ]);
+        } else {
+            // Third validation
+            $step2Data = request()->validate([
+                'company' => 'required|string',
+                'position' => 'required|string',
+            ]);
+        }
+        
+        return response()->json(['success' => true]);
+    }
+}
+PHP;
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse($code);
+
+        $method = $this->findMethod($ast, 'process');
+        $result = $this->analyzer->analyze($method);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('rules', $result);
+
+        // Should have all fields from all validate calls merged
+        $this->assertArrayHasKey('step', $result['rules']);
+        $this->assertArrayHasKey('name', $result['rules']);
+        $this->assertArrayHasKey('email', $result['rules']);
+        $this->assertArrayHasKey('company', $result['rules']);
+        $this->assertArrayHasKey('position', $result['rules']);
+    }
+
+    public function test_analyzes_request_validate_with_array_rules(): void
+    {
+        $code = <<<'PHP'
+<?php
+class TestController extends Controller
+{
+    public function store(Request $request)
+    {
+        $validated = request()->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email', 'unique:users,email'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ]);
+        
+        return response()->json($validated);
+    }
+}
+PHP;
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse($code);
+
+        $method = $this->findMethod($ast, 'store');
+        $result = $this->analyzer->analyze($method);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('rules', $result);
+        $this->assertIsArray($result['rules']['name']);
+        $this->assertIsArray($result['rules']['email']);
+        $this->assertIsArray($result['rules']['password']);
+        $this->assertContains('required', $result['rules']['name']);
+        $this->assertContains('string', $result['rules']['name']);
+        $this->assertContains('max:255', $result['rules']['name']);
+    }
+
+    public function test_detects_both_this_validate_and_request_validate(): void
+    {
+        $code = <<<'PHP'
+<?php
+class TestController extends Controller
+{
+    public function mixed(Request $request)
+    {
+        // Using $this->validate()
+        $basicData = $this->validate($request, [
+            'type' => 'required|string|in:basic,advanced',
+        ]);
+        
+        // Using request()->validate()
+        if ($basicData['type'] === 'advanced') {
+            $advancedData = request()->validate([
+                'advanced_option' => 'required|string',
+                'level' => 'required|integer|between:1,10',
+            ]);
+        }
+        
+        return response()->json(['success' => true]);
+    }
+}
+PHP;
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse($code);
+
+        $method = $this->findMethod($ast, 'mixed');
+        $result = $this->analyzer->analyze($method);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('rules', $result);
+
+        // Should have fields from both validation methods
+        $this->assertArrayHasKey('type', $result['rules']);
+        $this->assertArrayHasKey('advanced_option', $result['rules']);
+        $this->assertArrayHasKey('level', $result['rules']);
+    }
+
+    /**
+     * Helper method to find a method node in AST
+     */
+    private function findMethod(array $ast, string $methodName): ?Node\Stmt\ClassMethod
+    {
+        $visitor = new class($methodName) extends NodeVisitorAbstract
+        {
+            private string $targetMethod;
+
+            private ?Node\Stmt\ClassMethod $method = null;
+
+            public function __construct(string $targetMethod)
+            {
+                $this->targetMethod = $targetMethod;
+            }
+
+            public function enterNode(Node $node)
+            {
+                if ($node instanceof Node\Stmt\ClassMethod &&
+                    $node->name->toString() === $this->targetMethod) {
+                    $this->method = $node;
+
+                    return NodeTraverser::STOP_TRAVERSAL;
+                }
+            }
+
+            public function getMethod(): ?Node\Stmt\ClassMethod
+            {
+                return $this->method;
+            }
+        };
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        return $visitor->getMethod();
+    }
+}

--- a/tests/Unit/Analyzers/InlineValidationAnalyzerRequestVariableTest.php
+++ b/tests/Unit/Analyzers/InlineValidationAnalyzerRequestVariableTest.php
@@ -1,0 +1,375 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelSpectrum\Tests\Unit\Analyzers;
+
+use LaravelSpectrum\Analyzers\InlineValidationAnalyzer;
+use LaravelSpectrum\Support\TypeInference;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
+
+class InlineValidationAnalyzerRequestVariableTest extends TestCase
+{
+    private InlineValidationAnalyzer $analyzer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->analyzer = new InlineValidationAnalyzer(new TypeInference);
+    }
+
+    public function test_analyzes_request_variable_validate_method(): void
+    {
+        $code = <<<'PHP'
+<?php
+class TestController extends Controller
+{
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:users',
+            'password' => 'required|string|min:8|confirmed',
+        ]);
+        
+        return response()->json($validated);
+    }
+}
+PHP;
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse($code);
+
+        $method = $this->findMethod($ast, 'store');
+        $result = $this->analyzer->analyze($method);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('rules', $result);
+        $this->assertArrayHasKey('name', $result['rules']);
+        $this->assertArrayHasKey('email', $result['rules']);
+        $this->assertArrayHasKey('password', $result['rules']);
+        $this->assertEquals('required|string|max:255', $result['rules']['name']);
+        $this->assertEquals('required|email|unique:users', $result['rules']['email']);
+        $this->assertEquals('required|string|min:8|confirmed', $result['rules']['password']);
+    }
+
+    public function test_analyzes_request_variable_validate_with_messages(): void
+    {
+        $code = <<<'PHP'
+<?php
+class TestController extends Controller
+{
+    public function update(Request $request, $id)
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:100',
+            'description' => 'nullable|string|max:500',
+        ], [
+            'name.required' => 'The product name is required.',
+            'name.max' => 'The product name cannot exceed 100 characters.',
+        ]);
+        
+        return response()->json($validated);
+    }
+}
+PHP;
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse($code);
+
+        $method = $this->findMethod($ast, 'update');
+        $result = $this->analyzer->analyze($method);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('messages', $result);
+        $this->assertEquals('The product name is required.', $result['messages']['name.required']);
+        $this->assertEquals('The product name cannot exceed 100 characters.', $result['messages']['name.max']);
+    }
+
+    public function test_analyzes_request_variable_validate_with_attributes(): void
+    {
+        $code = <<<'PHP'
+<?php
+class TestController extends Controller
+{
+    public function create(Request $request)
+    {
+        $validated = $request->validate([
+            'first_name' => 'required|string',
+            'last_name' => 'required|string',
+            'phone_number' => 'required|string|regex:/^[0-9]{10}$/',
+        ], [], [
+            'first_name' => 'First Name',
+            'last_name' => 'Last Name',
+            'phone_number' => 'Phone Number',
+        ]);
+        
+        return response()->json($validated);
+    }
+}
+PHP;
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse($code);
+
+        $method = $this->findMethod($ast, 'create');
+        $result = $this->analyzer->analyze($method);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('attributes', $result);
+        $this->assertEquals('First Name', $result['attributes']['first_name']);
+        $this->assertEquals('Last Name', $result['attributes']['last_name']);
+        $this->assertEquals('Phone Number', $result['attributes']['phone_number']);
+    }
+
+    public function test_analyzes_different_request_variable_names(): void
+    {
+        $code = <<<'PHP'
+<?php
+class TestController extends Controller
+{
+    public function store(Request $req)
+    {
+        // Using different variable name
+        $data1 = $req->validate([
+            'field1' => 'required|string',
+        ]);
+        
+        return response()->json($data1);
+    }
+    
+    public function update(Request $httpRequest)
+    {
+        // Using another variable name
+        $data2 = $httpRequest->validate([
+            'field2' => 'required|integer',
+        ]);
+        
+        return response()->json($data2);
+    }
+}
+PHP;
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse($code);
+
+        // Test first method
+        $method1 = $this->findMethod($ast, 'store');
+        $result1 = $this->analyzer->analyze($method1);
+
+        $this->assertNotEmpty($result1);
+        $this->assertArrayHasKey('field1', $result1['rules']);
+        $this->assertEquals('required|string', $result1['rules']['field1']);
+
+        // Test second method
+        $method2 = $this->findMethod($ast, 'update');
+        $result2 = $this->analyzer->analyze($method2);
+
+        $this->assertNotEmpty($result2);
+        $this->assertArrayHasKey('field2', $result2['rules']);
+        $this->assertEquals('required|integer', $result2['rules']['field2']);
+    }
+
+    public function test_analyzes_request_variable_validate_with_file_upload(): void
+    {
+        $code = <<<'PHP'
+<?php
+class TestController extends Controller
+{
+    public function upload(Request $request)
+    {
+        $validated = $request->validate([
+            'title' => 'required|string|max:255',
+            'document' => 'required|file|mimes:pdf,doc,docx|max:10240',
+            'thumbnail' => 'nullable|image|dimensions:min_width=200,min_height=200',
+        ]);
+        
+        return response()->json(['success' => true]);
+    }
+}
+PHP;
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse($code);
+
+        $method = $this->findMethod($ast, 'upload');
+        $result = $this->analyzer->analyze($method);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('rules', $result);
+        $this->assertEquals('required|file|mimes:pdf,doc,docx|max:10240', $result['rules']['document']);
+        $this->assertEquals('nullable|image|dimensions:min_width=200,min_height=200', $result['rules']['thumbnail']);
+    }
+
+    public function test_analyzes_multiple_request_variable_validate_calls(): void
+    {
+        $code = <<<'PHP'
+<?php
+class TestController extends Controller
+{
+    public function process(Request $request)
+    {
+        // First validation
+        $step1 = $request->validate([
+            'action' => 'required|string|in:create,update',
+        ]);
+        
+        if ($step1['action'] === 'create') {
+            // Second validation for create
+            $createData = $request->validate([
+                'title' => 'required|string',
+                'content' => 'required|string',
+            ]);
+        } else {
+            // Third validation for update
+            $updateData = $request->validate([
+                'id' => 'required|integer|exists:posts,id',
+                'title' => 'sometimes|string',
+            ]);
+        }
+        
+        return response()->json(['success' => true]);
+    }
+}
+PHP;
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse($code);
+
+        $method = $this->findMethod($ast, 'process');
+        $result = $this->analyzer->analyze($method);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('rules', $result);
+
+        // Should have all fields from all validate calls merged
+        $this->assertArrayHasKey('action', $result['rules']);
+        $this->assertArrayHasKey('title', $result['rules']);
+        $this->assertArrayHasKey('content', $result['rules']);
+        $this->assertArrayHasKey('id', $result['rules']);
+    }
+
+    public function test_analyzes_request_variable_validate_with_array_rules(): void
+    {
+        $code = <<<'PHP'
+<?php
+class TestController extends Controller
+{
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'username' => ['required', 'string', 'min:3', 'max:20', 'unique:users'],
+            'email' => ['required', 'email', 'confirmed'],
+            'terms' => ['required', 'accepted'],
+        ]);
+        
+        return response()->json($validated);
+    }
+}
+PHP;
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse($code);
+
+        $method = $this->findMethod($ast, 'store');
+        $result = $this->analyzer->analyze($method);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('rules', $result);
+        $this->assertIsArray($result['rules']['username']);
+        $this->assertIsArray($result['rules']['email']);
+        $this->assertIsArray($result['rules']['terms']);
+        $this->assertContains('required', $result['rules']['username']);
+        $this->assertContains('unique:users', $result['rules']['username']);
+    }
+
+    public function test_analyzes_mixed_validation_patterns(): void
+    {
+        $code = <<<'PHP'
+<?php
+class TestController extends Controller
+{
+    public function mixed(Request $request)
+    {
+        // Using $this->validate()
+        $basicData = $this->validate($request, [
+            'mode' => 'required|string|in:simple,advanced',
+        ]);
+        
+        // Using $request->validate()
+        $additionalData = $request->validate([
+            'setting1' => 'required|string',
+            'setting2' => 'required|boolean',
+        ]);
+        
+        // Using request()->validate()
+        $moreData = request()->validate([
+            'option1' => 'nullable|string',
+            'option2' => 'nullable|integer',
+        ]);
+        
+        return response()->json(['success' => true]);
+    }
+}
+PHP;
+
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
+        $ast = $parser->parse($code);
+
+        $method = $this->findMethod($ast, 'mixed');
+        $result = $this->analyzer->analyze($method);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('rules', $result);
+
+        // Should have fields from all three validation methods
+        $this->assertArrayHasKey('mode', $result['rules']);
+        $this->assertArrayHasKey('setting1', $result['rules']);
+        $this->assertArrayHasKey('setting2', $result['rules']);
+        $this->assertArrayHasKey('option1', $result['rules']);
+        $this->assertArrayHasKey('option2', $result['rules']);
+    }
+
+    /**
+     * Helper method to find a method node in AST
+     */
+    private function findMethod(array $ast, string $methodName): ?Node\Stmt\ClassMethod
+    {
+        $visitor = new class($methodName) extends NodeVisitorAbstract
+        {
+            private string $targetMethod;
+
+            private ?Node\Stmt\ClassMethod $method = null;
+
+            public function __construct(string $targetMethod)
+            {
+                $this->targetMethod = $targetMethod;
+            }
+
+            public function enterNode(Node $node)
+            {
+                if ($node instanceof Node\Stmt\ClassMethod &&
+                    $node->name->toString() === $this->targetMethod) {
+                    $this->method = $node;
+
+                    return NodeTraverser::STOP_TRAVERSAL;
+                }
+            }
+
+            public function getMethod(): ?Node\Stmt\ClassMethod
+            {
+                return $this->method;
+            }
+        };
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        return $visitor->getMethod();
+    }
+}


### PR DESCRIPTION
# 概要

Laravelのインラインバリデーションでよく使用される `request()->validate()` と `$request->validate()` パターンの検出機能を追加しました。

## 変更内容

### 新機能の追加
- `InlineValidationAnalyzer` に `request()->validate()` パターンの検出ロジックを追加
- `InlineValidationAnalyzer` に `$request->validate()` パターンの検出ロジックを追加
- 一般的なRequest変数名（request, req, httpRequest, r, input, data, requestData）をサポート

### テストの追加
- `request()->validate()` パターン用の包括的なテストスイートを作成
- `$request->validate()` パターン用の包括的なテストスイートを作成
- ファイルアップロード検出との統合テストを含む
- 複数のバリデーションパターンの混在使用をテスト

### デモアプリケーションの更新
- 新しいバリデーションパターンを使用するコントローラーメソッドを追加
- APIルートの追加
- OpenAPIドキュメント生成が正常に動作することを確認

### サポートするバリデーションパターン
現在、以下のパターンをサポートしています：
- ✅ `$this->validate($request, [...])`
- ✅ `request()->validate([...])`
- ✅ `$request->validate([...])`
- ✅ `Validator::make($request->all(), [...])`

## 関連情報

- すべてのテスト（336個）が成功
- PHPStanによる静的解析をパス
- Laravel Pintによるコードフォーマットを適用済み