### PR TITLE
Refactoring: PHPUnitテストアノテーションの現代化

### DIFF
--- a/tests/Feature/AuthenticationIntegrationTest.php
+++ b/tests/Feature/AuthenticationIntegrationTest.php
@@ -5,6 +5,7 @@ namespace LaravelSpectrum\Tests\Feature;
 use Illuminate\Support\Facades\Route;
 use LaravelSpectrum\Cache\DocumentationCache;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class AuthenticationIntegrationTest extends TestCase
 {
@@ -24,7 +25,7 @@ class AuthenticationIntegrationTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_includes_authentication_in_generated_openapi_spec()
     {
         // テスト用のルートを作成
@@ -65,7 +66,7 @@ class AuthenticationIntegrationTest extends TestCase
         $this->assertEquals([['apiAuth' => []]], $adminUsers['security']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_oauth2_authentication_for_passport()
     {
         // Passport認証のルート

--- a/tests/Feature/CacheCommandTest.php
+++ b/tests/Feature/CacheCommandTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Route;
 use LaravelSpectrum\Cache\DocumentationCache;
 use LaravelSpectrum\Tests\Fixtures\Controllers\UserController;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class CacheCommandTest extends TestCase
 {
@@ -25,7 +26,7 @@ class CacheCommandTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_can_clear_cache()
     {
         // Arrange - Create some cache
@@ -43,7 +44,7 @@ class CacheCommandTest extends TestCase
         $this->assertEquals(0, $stats['total_files']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_show_cache_statistics()
     {
         // Arrange - Create some cache
@@ -60,7 +61,7 @@ class CacheCommandTest extends TestCase
             ->assertSuccessful();
     }
 
-    /** @test */
+    #[Test]
     public function it_can_warm_cache()
     {
         // Arrange
@@ -77,7 +78,7 @@ class CacheCommandTest extends TestCase
         $this->assertGreaterThan(0, $stats['total_files']);
     }
 
-    /** @test */
+    #[Test]
     public function it_shows_error_for_invalid_action()
     {
         $this->artisan('spectrum:cache invalid')

--- a/tests/Feature/ControllerEnumParameterTest.php
+++ b/tests/Feature/ControllerEnumParameterTest.php
@@ -4,6 +4,7 @@ namespace LaravelSpectrum\Tests\Feature;
 
 use LaravelSpectrum\Tests\Fixtures\Controllers\EnumTestController;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ControllerEnumParameterTest extends TestCase
 {
@@ -15,7 +16,7 @@ class ControllerEnumParameterTest extends TestCase
         $router->get('api/status', [EnumTestController::class, 'getStatus']);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_enum_parameters_in_controller_methods()
     {
         // Act
@@ -58,7 +59,7 @@ class ControllerEnumParameterTest extends TestCase
         $this->assertEquals(['active', 'inactive', 'pending'], $statusParam['schema']['enum']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_enum_response_schemas()
     {
         // Act

--- a/tests/Feature/ErrorResponseIntegrationTest.php
+++ b/tests/Feature/ErrorResponseIntegrationTest.php
@@ -5,6 +5,7 @@ namespace LaravelSpectrum\Tests\Feature;
 use Illuminate\Support\Facades\Route;
 use LaravelSpectrum\Cache\DocumentationCache;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ErrorResponseIntegrationTest extends TestCase
 {
@@ -29,7 +30,7 @@ class ErrorResponseIntegrationTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_includes_error_responses_in_generated_openapi_spec()
     {
         // テスト用のルートを作成

--- a/tests/Feature/GenerateDocsCommandTest.php
+++ b/tests/Feature/GenerateDocsCommandTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Route;
 use LaravelSpectrum\Cache\DocumentationCache;
 use LaravelSpectrum\Tests\Fixtures\Controllers\UserController;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class GenerateDocsCommandTest extends TestCase
 {
@@ -31,7 +32,7 @@ class GenerateDocsCommandTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_openapi_documentation()
     {
         // Arrange
@@ -55,7 +56,7 @@ class GenerateDocsCommandTest extends TestCase
         $this->assertArrayHasKey('/api/users', $openapi['paths']);
     }
 
-    /** @test */
+    #[Test]
     public function it_clears_cache_when_clear_cache_option_is_specified()
     {
         // Arrange
@@ -75,7 +76,7 @@ class GenerateDocsCommandTest extends TestCase
         $this->assertEquals(1, $stats['total_files']); // Only the newly created cache
     }
 
-    /** @test */
+    #[Test]
     public function it_disables_cache_when_no_cache_option_is_specified()
     {
         // Arrange
@@ -88,7 +89,7 @@ class GenerateDocsCommandTest extends TestCase
             ->assertSuccessful();
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_yaml_format_when_specified()
     {
         // Arrange
@@ -105,7 +106,7 @@ class GenerateDocsCommandTest extends TestCase
         $this->assertStringContainsString('openapi: 3.0.0', $content);
     }
 
-    /** @test */
+    #[Test]
     public function it_uses_custom_output_path_when_specified()
     {
         // Arrange
@@ -124,7 +125,7 @@ class GenerateDocsCommandTest extends TestCase
         File::deleteDirectory(storage_path('custom'));
     }
 
-    /** @test */
+    #[Test]
     public function it_shows_warning_when_no_routes_found()
     {
         // Arrange - No routes configured

--- a/tests/Feature/LumenCompatibilityTest.php
+++ b/tests/Feature/LumenCompatibilityTest.php
@@ -9,17 +9,18 @@ use LaravelSpectrum\Generators\OpenApiGenerator;
 use LaravelSpectrum\Support\LumenCompatibilityHelper;
 use LaravelSpectrum\Support\TypeInference;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class LumenCompatibilityTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_detects_lumen_environment()
     {
         // In test environment, we should not be in Lumen
         $this->assertFalse(LumenCompatibilityHelper::isLumen());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_correct_route_patterns_for_laravel()
     {
         config(['spectrum.route_patterns' => ['api/*']]);
@@ -29,7 +30,7 @@ class LumenCompatibilityTest extends TestCase
         $this->assertEquals(['api/*'], $patterns);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_routes_collection()
     {
         $routes = LumenCompatibilityHelper::getRoutes();
@@ -37,7 +38,7 @@ class LumenCompatibilityTest extends TestCase
         $this->assertNotNull($routes);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_openapi_with_inline_validation()
     {
         // Create a test controller with inline validation
@@ -173,7 +174,7 @@ class LumenCompatibilityTest extends TestCase
         unlink($tempFile);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_validator_make_pattern()
     {
         $controllerInfo = [
@@ -228,7 +229,7 @@ class LumenCompatibilityTest extends TestCase
         $this->assertStringContainsString('Validation', $operation['responses']['422']['description']);
     }
 
-    /** @test */
+    #[Test]
     public function it_prefers_form_request_over_inline_validation()
     {
         $controllerInfo = [
@@ -296,7 +297,7 @@ class LumenCompatibilityTest extends TestCase
         $this->assertArrayNotHasKey('name', $schema['properties']); // From inline validation, should not be present
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_custom_validation_messages_and_attributes()
     {
         $inlineValidationAnalyzer = new InlineValidationAnalyzer(new TypeInference);

--- a/tests/Feature/OpenApiGeneratorTest.php
+++ b/tests/Feature/OpenApiGeneratorTest.php
@@ -11,6 +11,7 @@ use LaravelSpectrum\Tests\Fixtures\Controllers\UserController;
 use LaravelSpectrum\Tests\Fixtures\StoreUserRequest;
 use LaravelSpectrum\Tests\TestCase;
 use Mockery;
+use PHPUnit\Framework\Attributes\Test;
 
 class OpenApiGeneratorTest extends TestCase
 {
@@ -30,7 +31,7 @@ class OpenApiGeneratorTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_valid_openapi_specification()
     {
         // Arrange
@@ -54,7 +55,7 @@ class OpenApiGeneratorTest extends TestCase
         $this->assertArrayHasKey('post', $openapi['paths']['/api/users']);
     }
 
-    /** @test */
+    #[Test]
     public function it_includes_request_body_for_post_requests()
     {
         // Arrange
@@ -75,7 +76,7 @@ class OpenApiGeneratorTest extends TestCase
         $this->assertArrayHasKey('application/json', $operation['requestBody']['content']);
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_security_requirements_for_authenticated_routes()
     {
         // Arrange
@@ -92,7 +93,7 @@ class OpenApiGeneratorTest extends TestCase
         $this->assertArrayHasKey('sanctumAuth', $operation['security'][0]);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_proper_path_parameters()
     {
         // Arrange
@@ -116,7 +117,7 @@ class OpenApiGeneratorTest extends TestCase
         $this->assertFalse(array_values($commentParam)[0]['required']);
     }
 
-    /** @test */
+    #[Test]
     public function it_includes_api_info_and_servers()
     {
         // Arrange
@@ -137,7 +138,7 @@ class OpenApiGeneratorTest extends TestCase
         $this->assertEquals('https://example.com/api', $openapi['servers'][0]['url']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_tags_from_route_uri()
     {
         // Arrange

--- a/tests/Performance/CachePerformanceTest.php
+++ b/tests/Performance/CachePerformanceTest.php
@@ -7,6 +7,7 @@ use LaravelSpectrum\Analyzers\RouteAnalyzer;
 use LaravelSpectrum\Cache\DocumentationCache;
 use LaravelSpectrum\Tests\Fixtures\Controllers\UserController;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class CachePerformanceTest extends TestCase
 {
@@ -26,7 +27,7 @@ class CachePerformanceTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_improves_generation_performance()
     {
         // 大量のルートを作成

--- a/tests/Unit/Analyzers/AST/ConditionalRulesTest.php
+++ b/tests/Unit/Analyzers/AST/ConditionalRulesTest.php
@@ -7,6 +7,7 @@ use LaravelSpectrum\Analyzers\FormRequestAnalyzer;
 use LaravelSpectrum\Cache\DocumentationCache;
 use LaravelSpectrum\Support\TypeInference;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ConditionalRulesTest extends TestCase
 {
@@ -26,7 +27,7 @@ class ConditionalRulesTest extends TestCase
         $this->analyzer = new FormRequestAnalyzer(new TypeInference, $cache);
     }
 
-    /** @test */
+    #[Test]
     public function it_analyzes_http_method_conditions()
     {
         $requestClass = new class extends FormRequest
@@ -83,7 +84,7 @@ class ConditionalRulesTest extends TestCase
         $this->assertContains('unique:users', $mergedRules['email']);
     }
 
-    /** @test */
+    #[Test]
     public function it_analyzes_nested_conditions()
     {
         $requestClass = new class extends FormRequest
@@ -129,7 +130,7 @@ class ConditionalRulesTest extends TestCase
         $this->assertEquals('user_method', $adminRuleSet['conditions'][1]['type']);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_early_returns()
     {
         $requestClass = new class extends FormRequest
@@ -174,7 +175,7 @@ class ConditionalRulesTest extends TestCase
         $this->assertEmpty($deleteRules['rules']);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_elseif_conditions()
     {
         $requestClass = new class extends FormRequest
@@ -211,7 +212,7 @@ class ConditionalRulesTest extends TestCase
         $this->assertStringContainsString('archived', $putRules['rules']['status']);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_request_helper_conditions()
     {
         $requestClass = new class extends FormRequest
@@ -241,7 +242,7 @@ class ConditionalRulesTest extends TestCase
         $this->assertEquals('POST', $postRules['conditions'][0]['method']);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_array_validation_rules()
     {
         $requestClass = new class extends FormRequest
@@ -275,7 +276,7 @@ class ConditionalRulesTest extends TestCase
         $this->assertContains('max:50', $postRules['rules']['tags.*']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_parameters_from_conditional_rules()
     {
         $requestClass = new class extends FormRequest
@@ -315,7 +316,7 @@ class ConditionalRulesTest extends TestCase
         $this->assertTrue($emailParam['required']);
     }
 
-    /** @test */
+    #[Test]
     public function it_falls_back_to_regular_extraction_when_no_conditions()
     {
         $requestClass = new class extends FormRequest
@@ -341,7 +342,7 @@ class ConditionalRulesTest extends TestCase
         $this->assertEmpty($result['conditional_rules']['rules_sets'][0]['conditions']);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_complex_conditions()
     {
         $requestClass = new class extends FormRequest
@@ -371,7 +372,7 @@ class ConditionalRulesTest extends TestCase
         $this->assertStringContainsString('isPremium', $premiumRules['conditions'][0]['expression']);
     }
 
-    /** @test */
+    #[Test]
     public function it_calculates_probability_correctly()
     {
         $requestClass = new class extends FormRequest

--- a/tests/Unit/Analyzers/AuthenticationAnalyzerTest.php
+++ b/tests/Unit/Analyzers/AuthenticationAnalyzerTest.php
@@ -4,6 +4,7 @@ namespace LaravelSpectrum\Tests\Unit\Analyzers;
 
 use LaravelSpectrum\Analyzers\AuthenticationAnalyzer;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class AuthenticationAnalyzerTest extends TestCase
 {
@@ -15,7 +16,7 @@ class AuthenticationAnalyzerTest extends TestCase
         $this->analyzer = new AuthenticationAnalyzer;
     }
 
-    /** @test */
+    #[Test]
     public function it_analyzes_routes_with_authentication()
     {
         $routes = [
@@ -47,7 +48,7 @@ class AuthenticationAnalyzerTest extends TestCase
         $this->assertArrayNotHasKey(1, $result['routes']); // publicルートには認証なし
     }
 
-    /** @test */
+    #[Test]
     public function it_analyzes_single_route_authentication()
     {
         $route = [
@@ -62,7 +63,7 @@ class AuthenticationAnalyzerTest extends TestCase
         $this->assertTrue($auth['required']);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_null_for_routes_without_authentication()
     {
         $route = [
@@ -75,7 +76,7 @@ class AuthenticationAnalyzerTest extends TestCase
         $this->assertNull($auth);
     }
 
-    /** @test */
+    #[Test]
     public function it_loads_custom_schemes_from_config()
     {
         config(['spectrum.authentication.custom_schemes' => [
@@ -101,7 +102,7 @@ class AuthenticationAnalyzerTest extends TestCase
         $this->assertEquals('jwtAuth', $auth['scheme']['name']);
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_global_authentication_when_enabled()
     {
         config(['spectrum.authentication.global' => [
@@ -122,7 +123,7 @@ class AuthenticationAnalyzerTest extends TestCase
         $this->assertTrue($globalAuth['required']);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_null_when_global_authentication_is_disabled()
     {
         config(['spectrum.authentication.global' => [

--- a/tests/Unit/Analyzers/ControllerAnalyzerTest.php
+++ b/tests/Unit/Analyzers/ControllerAnalyzerTest.php
@@ -4,6 +4,7 @@ namespace LaravelSpectrum\Tests\Unit\Analyzers;
 
 use LaravelSpectrum\Analyzers\ControllerAnalyzer;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ControllerAnalyzerTest extends TestCase
 {
@@ -15,7 +16,7 @@ class ControllerAnalyzerTest extends TestCase
         $this->analyzer = app(ControllerAnalyzer::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_fractal_item_usage()
     {
         $controller = TestFractalController::class;
@@ -27,7 +28,7 @@ class ControllerAnalyzerTest extends TestCase
         $this->assertEquals('item', $result['fractal']['type']);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_fractal_collection_usage()
     {
         $controller = TestFractalController::class;
@@ -39,7 +40,7 @@ class ControllerAnalyzerTest extends TestCase
         $this->assertEquals('collection', $result['fractal']['type']);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_fractal_with_includes()
     {
         $controller = TestFractalController::class;
@@ -50,7 +51,7 @@ class ControllerAnalyzerTest extends TestCase
         $this->assertTrue($result['fractal']['hasIncludes']);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_both_resource_and_fractal()
     {
         $controller = TestMixedController::class;

--- a/tests/Unit/Analyzers/FractalTransformerAnalyzerTest.php
+++ b/tests/Unit/Analyzers/FractalTransformerAnalyzerTest.php
@@ -7,6 +7,7 @@ use LaravelSpectrum\Tests\Fixtures\Transformers\ComplexTransformer;
 use LaravelSpectrum\Tests\Fixtures\Transformers\PostTransformer;
 use LaravelSpectrum\Tests\Fixtures\Transformers\UserTransformer;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class FractalTransformerAnalyzerTest extends TestCase
 {
@@ -18,7 +19,7 @@ class FractalTransformerAnalyzerTest extends TestCase
         $this->analyzer = new FractalTransformerAnalyzer;
     }
 
-    /** @test */
+    #[Test]
     public function it_analyzes_basic_fractal_transformer()
     {
         $result = $this->analyzer->analyze(UserTransformer::class);
@@ -41,7 +42,7 @@ class FractalTransformerAnalyzerTest extends TestCase
         $this->assertEquals('string', $result['properties']['updated_at']['type']);
     }
 
-    /** @test */
+    #[Test]
     public function it_extracts_available_includes()
     {
         $result = $this->analyzer->analyze(UserTransformer::class);
@@ -57,7 +58,7 @@ class FractalTransformerAnalyzerTest extends TestCase
         $this->assertFalse($result['availableIncludes']['profile']['collection']);
     }
 
-    /** @test */
+    #[Test]
     public function it_extracts_default_includes()
     {
         $result = $this->analyzer->analyze(UserTransformer::class);
@@ -67,7 +68,7 @@ class FractalTransformerAnalyzerTest extends TestCase
         $this->assertNotContains('posts', $result['defaultIncludes']);
     }
 
-    /** @test */
+    #[Test]
     public function it_analyzes_transformer_with_nullable_fields()
     {
         $result = $this->analyzer->analyze(PostTransformer::class);
@@ -79,7 +80,7 @@ class FractalTransformerAnalyzerTest extends TestCase
         $this->assertTrue($result['properties']['published_at']['nullable']);
     }
 
-    /** @test */
+    #[Test]
     public function it_analyzes_complex_transformer_with_nested_data()
     {
         $result = $this->analyzer->analyze(ComplexTransformer::class);
@@ -102,21 +103,21 @@ class FractalTransformerAnalyzerTest extends TestCase
         $this->assertEquals('object', $result['properties']['metrics']['type']);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_empty_array_for_non_transformer_class()
     {
         $result = $this->analyzer->analyze(\stdClass::class);
         $this->assertEmpty($result);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_empty_array_for_non_existent_class()
     {
         $result = $this->analyzer->analyze('NonExistentClass');
         $this->assertEmpty($result);
     }
 
-    /** @test */
+    #[Test]
     public function it_analyzes_include_methods_with_null_returns()
     {
         $result = $this->analyzer->analyze(ComplexTransformer::class);
@@ -127,7 +128,7 @@ class FractalTransformerAnalyzerTest extends TestCase
         $this->assertContains($result['availableIncludes']['nested_resource']['type'], ['object', 'null']);
     }
 
-    /** @test */
+    #[Test]
     public function it_identifies_transformer_classes_from_include_methods()
     {
         $result = $this->analyzer->analyze(UserTransformer::class);
@@ -139,7 +140,7 @@ class FractalTransformerAnalyzerTest extends TestCase
         $this->assertEquals('ProfileTransformer', $result['availableIncludes']['profile']['transformer']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_appropriate_examples_for_properties()
     {
         $result = $this->analyzer->analyze(UserTransformer::class);

--- a/tests/Unit/Analyzers/InlineValidationAnalyzerTest.php
+++ b/tests/Unit/Analyzers/InlineValidationAnalyzerTest.php
@@ -8,6 +8,7 @@ use LaravelSpectrum\Tests\TestCase;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
+use PHPUnit\Framework\Attributes\Test;
 
 class InlineValidationAnalyzerTest extends TestCase
 {
@@ -22,7 +23,7 @@ class InlineValidationAnalyzerTest extends TestCase
         $this->analyzer = new InlineValidationAnalyzer(new TypeInference);
     }
 
-    /** @test */
+    #[Test]
     public function it_analyzes_basic_inline_validation()
     {
         $code = '<?php
@@ -45,7 +46,7 @@ class InlineValidationAnalyzerTest extends TestCase
         $this->assertEquals('required|email|unique:users', $result['rules']['email']);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_array_format_rules()
     {
         $code = '<?php
@@ -68,7 +69,7 @@ class InlineValidationAnalyzerTest extends TestCase
         $this->assertEquals(['required', 'email', 'unique:users,email'], $result['rules']['email']);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_custom_messages()
     {
         $code = '<?php
@@ -94,7 +95,7 @@ class InlineValidationAnalyzerTest extends TestCase
         $this->assertEquals('メールアドレスは必須です', $result['messages']['email.required']);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_custom_attributes()
     {
         $code = '<?php
@@ -117,7 +118,7 @@ class InlineValidationAnalyzerTest extends TestCase
         $this->assertEquals('Full Name', $result['attributes']['name']);
     }
 
-    /** @test */
+    #[Test]
     public function it_analyzes_validator_make()
     {
         $code = '<?php
@@ -142,7 +143,7 @@ class InlineValidationAnalyzerTest extends TestCase
         $this->assertEquals('required|email', $result['rules']['email']);
     }
 
-    /** @test */
+    #[Test]
     public function it_merges_multiple_validations()
     {
         $code = '<?php
@@ -170,7 +171,7 @@ class InlineValidationAnalyzerTest extends TestCase
         $this->assertEquals('required|email', $result['rules']['email']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_parameters_from_validation()
     {
         $validation = [
@@ -212,7 +213,7 @@ class InlineValidationAnalyzerTest extends TestCase
         $this->assertEquals(['active', 'inactive'], $statusParam['enum']);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_conditional_required_rules()
     {
         $validation = [
@@ -228,7 +229,7 @@ class InlineValidationAnalyzerTest extends TestCase
         $this->assertTrue($parameters[1]['required']); // required_unless is considered required
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_empty_array_for_methods_without_validation()
     {
         $code = '<?php

--- a/tests/Unit/DocumentationCacheTest.php
+++ b/tests/Unit/DocumentationCacheTest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\File;
 use LaravelSpectrum\Cache\DocumentationCache;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class DocumentationCacheTest extends TestCase
 {
@@ -24,7 +25,7 @@ class DocumentationCacheTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_caches_analysis_results()
     {
         $callCount = 0;
@@ -49,7 +50,7 @@ class DocumentationCacheTest extends TestCase
         $this->assertEquals(1, $callCount); // コールバックは呼ばれない
     }
 
-    /** @test */
+    #[Test]
     public function it_invalidates_cache_when_dependencies_change()
     {
         $tempFile = storage_path('test_dependency.php');
@@ -83,7 +84,7 @@ class DocumentationCacheTest extends TestCase
         File::delete($tempFile);
     }
 
-    /** @test */
+    #[Test]
     public function it_caches_form_request_analysis()
     {
         $testRequest = new class extends FormRequest
@@ -115,7 +116,7 @@ class DocumentationCacheTest extends TestCase
         $this->assertEquals(1, $callCount);
     }
 
-    /** @test */
+    #[Test]
     public function it_provides_cache_statistics()
     {
         // いくつかのアイテムをキャッシュ
@@ -131,7 +132,7 @@ class DocumentationCacheTest extends TestCase
         $this->assertNotNull($stats['newest_file']);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_corrupted_cache_gracefully()
     {
         $cacheDir = config('spectrum.cache.directory', storage_path('app/spectrum/cache'));
@@ -154,7 +155,7 @@ class DocumentationCacheTest extends TestCase
         $this->assertEquals(1, $callCount);
     }
 
-    /** @test */
+    #[Test]
     public function it_respects_cache_enabled_setting()
     {
         // キャッシュを無効化
@@ -179,7 +180,7 @@ class DocumentationCacheTest extends TestCase
         $this->assertEquals(2, $callCount);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_resource_dependencies()
     {
         $resourceFile = storage_path('TestResource.php');
@@ -242,7 +243,7 @@ class DependencyResource {
         File::delete($dependencyFile);
     }
 
-    /** @test */
+    #[Test]
     public function it_caches_route_analysis()
     {
         $callCount = 0;
@@ -266,7 +267,7 @@ class DependencyResource {
         $this->assertEquals(1, $callCount);
     }
 
-    /** @test */
+    #[Test]
     public function it_forgets_cache_entries()
     {
         // キャッシュにデータを保存
@@ -296,14 +297,14 @@ class DependencyResource {
         $this->assertEquals(['route3'], $data);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_false_when_forgetting_non_existent_cache()
     {
         $result = $this->cache->forget('non_existent_key');
         $this->assertFalse($result);
     }
 
-    /** @test */
+    #[Test]
     public function it_forgets_cache_by_pattern()
     {
         // 複数のリソースキャッシュを作成

--- a/tests/Unit/FormRequestAnalyzerTest.php
+++ b/tests/Unit/FormRequestAnalyzerTest.php
@@ -9,6 +9,7 @@ use LaravelSpectrum\Cache\DocumentationCache;
 use LaravelSpectrum\Support\TypeInference;
 use LaravelSpectrum\Tests\Fixtures\StoreUserRequest;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class FormRequestAnalyzerTest extends TestCase
 {
@@ -28,7 +29,7 @@ class FormRequestAnalyzerTest extends TestCase
         $this->analyzer = new FormRequestAnalyzer(new TypeInference, $cache);
     }
 
-    /** @test */
+    #[Test]
     public function it_extracts_validation_rules_from_form_request()
     {
         // Act
@@ -44,7 +45,7 @@ class FormRequestAnalyzerTest extends TestCase
         $this->assertEquals('string', $nameParam['type']);
     }
 
-    /** @test */
+    #[Test]
     public function it_infers_types_from_validation_rules()
     {
         // Arrange - Create a test FormRequest
@@ -73,7 +74,7 @@ class FormRequestAnalyzerTest extends TestCase
         $this->assertEquals('string', $this->findParameterByName($parameters, 'email')['type']);
     }
 
-    /** @test */
+    #[Test]
     public function it_extracts_descriptions_from_attributes_method()
     {
         // Arrange
@@ -98,7 +99,7 @@ class FormRequestAnalyzerTest extends TestCase
         $this->assertEquals('ユーザー名', $nameParam['description']);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_array_rules()
     {
         // Arrange
@@ -125,7 +126,7 @@ class FormRequestAnalyzerTest extends TestCase
         $this->assertContains('max:255', $nameParam['validation']);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_empty_array_for_non_form_request()
     {
         // Act
@@ -136,7 +137,7 @@ class FormRequestAnalyzerTest extends TestCase
         $this->assertEmpty($parameters);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_optional_fields()
     {
         // Arrange
@@ -161,7 +162,7 @@ class FormRequestAnalyzerTest extends TestCase
         $this->assertFalse($this->findParameterByName($parameters, 'nullable_field')['required']);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_rule_objects()
     {
         // Skip test if using file-based analyzer since it can't instantiate Rule objects
@@ -199,7 +200,7 @@ class FormRequestAnalyzerTest extends TestCase
         $this->assertTrue($statusParam['required']);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_dynamic_rules()
     {
         // Skip test if using file-based analyzer
@@ -236,7 +237,7 @@ class FormRequestAnalyzerTest extends TestCase
         $this->assertTrue($nameParam['required']);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_php8_match_expression()
     {
         if (PHP_VERSION_ID < 80000) {
@@ -268,7 +269,7 @@ class FormRequestAnalyzerTest extends TestCase
         $this->assertNotEmpty($parameters);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_nested_array_rules()
     {
         // Arrange
@@ -295,7 +296,7 @@ class FormRequestAnalyzerTest extends TestCase
         $this->assertEquals('string', $userNameParam['type']);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_wildcard_array_rules()
     {
         // Arrange

--- a/tests/Unit/Generators/ConditionalSchemaGeneratorTest.php
+++ b/tests/Unit/Generators/ConditionalSchemaGeneratorTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Generators;
 
 use LaravelSpectrum\Generators\SchemaGenerator;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ConditionalSchemaGeneratorTest extends TestCase
 {
@@ -15,7 +16,7 @@ class ConditionalSchemaGeneratorTest extends TestCase
         $this->generator = new SchemaGenerator;
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_oneof_schema_for_conditional_parameters()
     {
         $parameters = [
@@ -80,7 +81,7 @@ class ConditionalSchemaGeneratorTest extends TestCase
         $this->assertContains('password', $postSchema['required']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_regular_schema_when_no_conditions()
     {
         $parameters = [
@@ -108,7 +109,7 @@ class ConditionalSchemaGeneratorTest extends TestCase
         $this->assertArrayHasKey('email', $schema['properties']);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_non_http_method_conditions()
     {
         $parameters = [
@@ -136,7 +137,7 @@ class ConditionalSchemaGeneratorTest extends TestCase
         $this->assertArrayHasKey('admin_field', $schema['properties']);
     }
 
-    /** @test */
+    #[Test]
     public function it_merges_duplicate_fields_correctly()
     {
         $parameters = [

--- a/tests/Unit/Generators/ErrorResponseGeneratorTest.php
+++ b/tests/Unit/Generators/ErrorResponseGeneratorTest.php
@@ -5,6 +5,7 @@ namespace LaravelSpectrum\Tests\Unit\Generators;
 use LaravelSpectrum\Generators\ErrorResponseGenerator;
 use LaravelSpectrum\Generators\ValidationMessageGenerator;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ErrorResponseGeneratorTest extends TestCase
 {
@@ -17,7 +18,7 @@ class ErrorResponseGeneratorTest extends TestCase
         $this->generator = new ErrorResponseGenerator($messageGenerator);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_401_unauthorized_response()
     {
         $responses = $this->generator->generateErrorResponses();
@@ -27,7 +28,7 @@ class ErrorResponseGeneratorTest extends TestCase
         $this->assertArrayHasKey('content', $responses['401']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_422_validation_error_response_with_form_request()
     {
         $formRequestData = [
@@ -50,7 +51,7 @@ class ErrorResponseGeneratorTest extends TestCase
         $this->assertArrayHasKey('password', $errorProperties);
     }
 
-    /** @test */
+    #[Test]
     public function it_includes_error_examples_in_422_response()
     {
         $formRequestData = [
@@ -67,7 +68,7 @@ class ErrorResponseGeneratorTest extends TestCase
         $this->assertEquals('The Email field is required.', $example['email'][0]);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_default_error_responses_for_authenticated_routes()
     {
         $responses = $this->generator->getDefaultErrorResponses('GET', true, false);
@@ -78,7 +79,7 @@ class ErrorResponseGeneratorTest extends TestCase
         $this->assertArrayHasKey('500', $responses);
     }
 
-    /** @test */
+    #[Test]
     public function it_excludes_auth_errors_for_public_routes()
     {
         $responses = $this->generator->getDefaultErrorResponses('GET', false, false);
@@ -89,7 +90,7 @@ class ErrorResponseGeneratorTest extends TestCase
         $this->assertArrayHasKey('500', $responses);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_custom_validation_messages()
     {
         $formRequestData = [

--- a/tests/Unit/Generators/OpenApiGeneratorTagsTest.php
+++ b/tests/Unit/Generators/OpenApiGeneratorTagsTest.php
@@ -16,6 +16,7 @@ use LaravelSpectrum\Generators\SecuritySchemeGenerator;
 use LaravelSpectrum\Support\PaginationDetector;
 use LaravelSpectrum\Tests\TestCase;
 use Mockery;
+use PHPUnit\Framework\Attributes\Test;
 use ReflectionClass;
 
 class OpenApiGeneratorTagsTest extends TestCase
@@ -81,7 +82,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_removes_parameters_from_tags()
     {
         $route = [
@@ -95,7 +96,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         $this->assertEquals(['Post'], $tags);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_nested_resources_with_multiple_tags()
     {
         $route = [
@@ -109,7 +110,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         $this->assertEquals(['Post', 'Comment'], $tags);
     }
 
-    /** @test */
+    #[Test]
     public function it_uses_controller_name_as_fallback_for_generic_paths()
     {
         $route = [
@@ -123,7 +124,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         $this->assertEquals(['User'], $tags);
     }
 
-    /** @test */
+    #[Test]
     public function it_respects_custom_tag_mappings_from_config()
     {
         // テスト用の設定値をセット
@@ -143,7 +144,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         $this->assertEquals(['Authentication'], $tags);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_deeply_nested_resources()
     {
         $route = [
@@ -157,7 +158,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         $this->assertEquals(['Post', 'Comment', 'Like'], $tags);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_simple_resource_paths()
     {
         $route = [
@@ -171,7 +172,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         $this->assertEquals(['User'], $tags);
     }
 
-    /** @test */
+    #[Test]
     public function it_ignores_common_prefixes()
     {
         $route = [
@@ -185,7 +186,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         $this->assertEquals(['User'], $tags);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_optional_parameters()
     {
         $route = [
@@ -199,7 +200,7 @@ class OpenApiGeneratorTagsTest extends TestCase
         $this->assertEquals(['Post'], $tags);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_custom_tag_mapping_with_exact_match()
     {
         $this->app['config']->set('spectrum.tags', [

--- a/tests/Unit/Generators/SchemaGeneratorTest.php
+++ b/tests/Unit/Generators/SchemaGeneratorTest.php
@@ -4,6 +4,7 @@ namespace LaravelSpectrum\Tests\Unit\Generators;
 
 use LaravelSpectrum\Generators\SchemaGenerator;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class SchemaGeneratorTest extends TestCase
 {
@@ -15,7 +16,7 @@ class SchemaGeneratorTest extends TestCase
         $this->generator = new SchemaGenerator;
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_schema_from_fractal_transformer()
     {
         $fractalData = [
@@ -41,7 +42,7 @@ class SchemaGeneratorTest extends TestCase
         $this->assertArrayHasKey('email', $schema['properties']['data']['properties']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_schema_with_available_includes()
     {
         $fractalData = [
@@ -72,7 +73,7 @@ class SchemaGeneratorTest extends TestCase
         $this->assertStringContainsString('Default include', $schema['properties']['data']['properties']['profile']['description']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_collection_schema_for_fractal()
     {
         $fractalData = [
@@ -94,7 +95,7 @@ class SchemaGeneratorTest extends TestCase
         $this->assertEquals('object', $schema['properties']['data']['items']['type']);
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_pagination_metadata_for_collections()
     {
         $fractalData = [
@@ -119,7 +120,7 @@ class SchemaGeneratorTest extends TestCase
         $this->assertArrayHasKey('total_pages', $pagination['properties']);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_nested_properties_in_fractal()
     {
         $fractalData = [
@@ -161,7 +162,7 @@ class SchemaGeneratorTest extends TestCase
         $this->assertArrayHasKey('is_active', $dataProperties['flags']['properties']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_schema_from_resource_without_example_keys()
     {
         $resourceStructure = [

--- a/tests/Unit/Generators/SecuritySchemeGeneratorTest.php
+++ b/tests/Unit/Generators/SecuritySchemeGeneratorTest.php
@@ -4,6 +4,7 @@ namespace LaravelSpectrum\Tests\Unit\Generators;
 
 use LaravelSpectrum\Generators\SecuritySchemeGenerator;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class SecuritySchemeGeneratorTest extends TestCase
 {
@@ -15,7 +16,7 @@ class SecuritySchemeGeneratorTest extends TestCase
         $this->generator = new SecuritySchemeGenerator;
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_bearer_token_security_scheme()
     {
         $authSchemes = [
@@ -36,7 +37,7 @@ class SecuritySchemeGeneratorTest extends TestCase
         $this->assertEquals('JWT', $securitySchemes['bearerAuth']['bearerFormat']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_api_key_security_scheme()
     {
         $authSchemes = [
@@ -56,7 +57,7 @@ class SecuritySchemeGeneratorTest extends TestCase
         $this->assertEquals('X-API-Key', $securitySchemes['apiKeyAuth']['name']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_oauth2_security_scheme()
     {
         $authSchemes = [
@@ -84,7 +85,7 @@ class SecuritySchemeGeneratorTest extends TestCase
         $this->assertArrayHasKey('flows', $securitySchemes['oauth2']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_endpoint_security()
     {
         $authentication = [
@@ -103,7 +104,7 @@ class SecuritySchemeGeneratorTest extends TestCase
         $this->assertEquals([], $security[0]['bearerAuth']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_oauth2_endpoint_security_with_scopes()
     {
         $authentication = [
@@ -122,7 +123,7 @@ class SecuritySchemeGeneratorTest extends TestCase
         $this->assertEquals(['read', 'write'], $security[0]['oauth2']);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_empty_array_for_non_required_authentication()
     {
         $authentication = [

--- a/tests/Unit/Generators/ValidationMessageGeneratorTest.php
+++ b/tests/Unit/Generators/ValidationMessageGeneratorTest.php
@@ -4,6 +4,7 @@ namespace LaravelSpectrum\Tests\Unit\Generators;
 
 use LaravelSpectrum\Generators\ValidationMessageGenerator;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ValidationMessageGeneratorTest extends TestCase
 {
@@ -15,7 +16,7 @@ class ValidationMessageGeneratorTest extends TestCase
         $this->generator = new ValidationMessageGenerator;
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_messages_for_required_rule()
     {
         $rules = ['name' => 'required|string'];
@@ -24,7 +25,7 @@ class ValidationMessageGeneratorTest extends TestCase
         $this->assertContains('The Name field is required.', $messages['name']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_messages_for_email_rule()
     {
         $rules = ['email' => 'required|email'];
@@ -33,7 +34,7 @@ class ValidationMessageGeneratorTest extends TestCase
         $this->assertContains('The Email must be a valid email address.', $messages['email']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_messages_for_min_rule_with_different_types()
     {
         // 文字列の場合
@@ -52,7 +53,7 @@ class ValidationMessageGeneratorTest extends TestCase
         $this->assertContains('The Tags must have at least 2 items.', $messages['tags']);
     }
 
-    /** @test */
+    #[Test]
     public function it_uses_custom_messages_when_provided()
     {
         $rules = ['email' => 'required|email'];
@@ -63,7 +64,7 @@ class ValidationMessageGeneratorTest extends TestCase
         $this->assertContains('メールアドレスは必須です。', $messages['email']);
     }
 
-    /** @test */
+    #[Test]
     public function it_humanizes_field_names()
     {
         $rules = [
@@ -77,7 +78,7 @@ class ValidationMessageGeneratorTest extends TestCase
         $this->assertContains('The User Email field is required.', $messages['user.email']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_sample_message()
     {
         $sampleMessage = $this->generator->generateSampleMessage('email', 'required|email');

--- a/tests/Unit/ResourceAnalyzerTest.php
+++ b/tests/Unit/ResourceAnalyzerTest.php
@@ -10,6 +10,7 @@ use LaravelSpectrum\Tests\Fixtures\DateTestResource;
 use LaravelSpectrum\Tests\Fixtures\NestedTestResource;
 use LaravelSpectrum\Tests\Fixtures\UserResource;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\Unit\Analyzers\Fixtures\ConditionalFieldsResource;
 use Tests\Unit\Analyzers\Fixtures\DateFormattingResource;
 use Tests\Unit\Analyzers\Fixtures\MethodChainResource;
@@ -38,7 +39,7 @@ class ResourceAnalyzerTest extends TestCase
         $this->analyzer = new ResourceAnalyzer($cache);
     }
 
-    /** @test */
+    #[Test]
     public function it_analyzes_resource_structure()
     {
         // Act
@@ -52,7 +53,7 @@ class ResourceAnalyzerTest extends TestCase
         $this->assertEquals('string', $structure['name']['type']);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_date_fields()
     {
         // Arrange - Resource with date fields
@@ -66,7 +67,7 @@ class ResourceAnalyzerTest extends TestCase
         $this->assertStringContainsString(' ', $structure['created_at']['example']);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_empty_array_for_non_resource_class()
     {
         // Act
@@ -77,7 +78,7 @@ class ResourceAnalyzerTest extends TestCase
         $this->assertEmpty($structure);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_nested_properties()
     {
         // Arrange
@@ -93,7 +94,7 @@ class ResourceAnalyzerTest extends TestCase
         $this->assertEquals('integer', $structure['posts_count']['type']);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_collection_fields()
     {
         // Arrange
@@ -109,7 +110,7 @@ class ResourceAnalyzerTest extends TestCase
         $this->assertEquals('array', $structure['categories']['type']);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_boolean_fields()
     {
         // Arrange
@@ -122,7 +123,7 @@ class ResourceAnalyzerTest extends TestCase
         $this->assertEquals('boolean', $structure['verified']['type']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_analyze_simple_resource()
     {
         $result = $this->analyzer->analyze(SimpleUserResource::class, true);
@@ -137,7 +138,7 @@ class ResourceAnalyzerTest extends TestCase
         $this->assertEquals('string', $result['properties']['email']['type']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_analyze_conditional_fields()
     {
         $result = $this->analyzer->analyze(ConditionalFieldsResource::class, true);
@@ -149,7 +150,7 @@ class ResourceAnalyzerTest extends TestCase
         $this->assertTrue($result['properties']['secret']['conditional']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_analyze_nested_resources()
     {
         $result = $this->analyzer->analyze(NestedResourcesResource::class, true);
@@ -162,7 +163,7 @@ class ResourceAnalyzerTest extends TestCase
         $this->assertEquals('array', $result['properties']['posts']['type']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_analyze_when_loaded_relationships()
     {
         $result = $this->analyzer->analyze(RelationshipResource::class, true);
@@ -173,7 +174,7 @@ class ResourceAnalyzerTest extends TestCase
         $this->assertEquals('posts', $result['properties']['posts']['relation']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_analyze_date_formatting()
     {
         $result = $this->analyzer->analyze(DateFormattingResource::class, true);
@@ -182,7 +183,7 @@ class ResourceAnalyzerTest extends TestCase
         $this->assertEquals('date-time', $result['properties']['created_at']['format']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_analyze_method_chains()
     {
         $result = $this->analyzer->analyze(MethodChainResource::class, true);
@@ -195,7 +196,7 @@ class ResourceAnalyzerTest extends TestCase
         $this->assertEquals('string', $result['properties']['full_name']['type']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_generate_openapi_schema()
     {
         $result = $this->analyzer->analyze(SimpleUserResource::class, true);
@@ -211,7 +212,7 @@ class ResourceAnalyzerTest extends TestCase
         $this->assertContains('email', $schema['required']);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_missing_toarray_method_gracefully()
     {
         $result = $this->analyzer->analyze(NoToArrayResource::class);
@@ -219,7 +220,7 @@ class ResourceAnalyzerTest extends TestCase
         $this->assertEmpty($result);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_analyze_resource_collection()
     {
         $result = $this->analyzer->analyze(UserCollection::class);
@@ -227,7 +228,7 @@ class ResourceAnalyzerTest extends TestCase
         $this->assertTrue($result['isCollection']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_analyze_with_method()
     {
         $result = $this->analyzer->analyze(ResourceWithMeta::class);

--- a/tests/Unit/RouteAnalyzerTest.php
+++ b/tests/Unit/RouteAnalyzerTest.php
@@ -11,6 +11,7 @@ use LaravelSpectrum\Tests\Fixtures\Controllers\ProfileController;
 use LaravelSpectrum\Tests\Fixtures\Controllers\SearchController;
 use LaravelSpectrum\Tests\Fixtures\Controllers\UserController;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class RouteAnalyzerTest extends TestCase
 {
@@ -30,7 +31,7 @@ class RouteAnalyzerTest extends TestCase
         $this->analyzer = new RouteAnalyzer($cache);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_detect_api_routes()
     {
         // Arrange
@@ -46,7 +47,7 @@ class RouteAnalyzerTest extends TestCase
         $this->assertEquals('api/users', $routes[0]['uri']);
     }
 
-    /** @test */
+    #[Test]
     public function it_extracts_route_parameters()
     {
         // Arrange
@@ -65,7 +66,7 @@ class RouteAnalyzerTest extends TestCase
         $this->assertFalse($routes[1]['parameters'][1]['required']);
     }
 
-    /** @test */
+    #[Test]
     public function it_filters_routes_by_configured_patterns()
     {
         // Arrange
@@ -81,7 +82,7 @@ class RouteAnalyzerTest extends TestCase
         $this->assertStringContainsString('api/v1', $routes[0]['uri']);
     }
 
-    /** @test */
+    #[Test]
     public function it_extracts_http_methods()
     {
         // Arrange
@@ -99,7 +100,7 @@ class RouteAnalyzerTest extends TestCase
         $this->assertContains('POST', $routes[2]['httpMethods']);
     }
 
-    /** @test */
+    #[Test]
     public function it_extracts_middleware()
     {
         // Arrange
@@ -115,7 +116,7 @@ class RouteAnalyzerTest extends TestCase
         $this->assertContains('throttle:api', $routes[0]['middleware']);
     }
 
-    /** @test */
+    #[Test]
     public function it_ignores_closure_routes()
     {
         // Arrange

--- a/tests/Unit/RouteAnalyzerWithPrefixTest.php
+++ b/tests/Unit/RouteAnalyzerWithPrefixTest.php
@@ -8,6 +8,7 @@ use LaravelSpectrum\Cache\DocumentationCache;
 use LaravelSpectrum\Tests\Fixtures\Controllers\PostController;
 use LaravelSpectrum\Tests\Fixtures\Controllers\UserController;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class RouteAnalyzerWithPrefixTest extends TestCase
 {
@@ -27,7 +28,7 @@ class RouteAnalyzerWithPrefixTest extends TestCase
         $this->analyzer = new RouteAnalyzer($cache);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_routes_with_prefix_groups()
     {
         // Arrange - Laravel 11スタイルのプレフィックスグループ
@@ -59,7 +60,7 @@ class RouteAnalyzerWithPrefixTest extends TestCase
         $this->assertEquals('api/users/{user}', $routes[2]['uri']);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_nested_prefix_groups()
     {
         // Arrange - ネストされたプレフィックスグループ
@@ -86,7 +87,7 @@ class RouteAnalyzerWithPrefixTest extends TestCase
         $this->assertEquals('api/v2/users', $routes[2]['uri']);
     }
 
-    /** @test */
+    #[Test]
     public function it_respects_custom_route_patterns_with_prefix()
     {
         // Arrange
@@ -111,7 +112,7 @@ class RouteAnalyzerWithPrefixTest extends TestCase
         $this->assertEquals('api/v2/posts', $routes[1]['uri']);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_laravel_11_style_api_routing()
     {
         // Arrange - Laravel 11のwithRouting設定をシミュレート

--- a/tests/Unit/Support/AuthenticationDetectorTest.php
+++ b/tests/Unit/Support/AuthenticationDetectorTest.php
@@ -4,10 +4,11 @@ namespace LaravelSpectrum\Tests\Unit\Support;
 
 use LaravelSpectrum\Support\AuthenticationDetector;
 use LaravelSpectrum\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class AuthenticationDetectorTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_detects_sanctum_authentication()
     {
         $middleware = ['auth:sanctum', 'throttle:api'];
@@ -20,7 +21,7 @@ class AuthenticationDetectorTest extends TestCase
         $this->assertEquals('sanctumAuth', $scheme['name']);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_passport_authentication()
     {
         $middleware = ['passport', 'scope:read'];
@@ -32,7 +33,7 @@ class AuthenticationDetectorTest extends TestCase
         $this->assertEquals('passportAuth', $scheme['name']);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_basic_authentication()
     {
         $middleware = ['auth.basic'];
@@ -44,7 +45,7 @@ class AuthenticationDetectorTest extends TestCase
         $this->assertEquals('basicAuth', $scheme['name']);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_api_key_authentication()
     {
         $middleware = ['check-api-key'];
@@ -56,7 +57,7 @@ class AuthenticationDetectorTest extends TestCase
         $this->assertEquals('apiKeyAuth', $scheme['name']);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_null_for_non_auth_middleware()
     {
         $middleware = ['throttle:60,1', 'cors'];
@@ -65,7 +66,7 @@ class AuthenticationDetectorTest extends TestCase
         $this->assertNull($scheme);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_custom_guard_authentication()
     {
         $middleware = ['auth:admin'];
@@ -77,7 +78,7 @@ class AuthenticationDetectorTest extends TestCase
         $this->assertEquals('adminAuth', $scheme['name']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_add_custom_authentication_schemes()
     {
         AuthenticationDetector::addCustomScheme('my-custom-auth', [
@@ -95,7 +96,7 @@ class AuthenticationDetectorTest extends TestCase
         $this->assertEquals('query', $scheme['in']);
     }
 
-    /** @test */
+    #[Test]
     public function it_detects_multiple_authentication_schemes()
     {
         $middleware = ['auth:sanctum', 'auth.basic', 'throttle'];


### PR DESCRIPTION
# 概要

PHPUnit 10以降で推奨されるPHP 8の属性を使用したテスト記法に全テストファイルを移行しました。

## 変更内容

PHPUnitの古い`@test`アノテーションから、PHP 8の`#[Test]`属性への移行を実施しました。

- 全25個のテストファイルで`/** @test */`を`#[Test]`に置換
- 各テストファイルに`use PHPUnit\Framework\Attributes\Test;`のインポートを追加
- Laravel Pintによるコードフォーマットの適用
- すべてのテストが正常に動作することを確認済み

## 関連情報

- PHPUnit 10以降では属性ベースのアノテーションが推奨されています
- この変更により、より現代的なPHPコードスタイルに準拠します