### PR TITLE
ci: replace Release Please with manual release and git-cliff CHANGELOG generation

### DIFF
--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -1,0 +1,48 @@
+# git-cliff configuration for CHANGELOG generation
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.\n
+"""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/wadakatu/laravel-spectrum/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [Unreleased]
+{% endif %}\
+
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | split(pat="\n") | first | trim }}
+    {%- endfor %}
+{% endfor %}\n
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_preprocessors = [
+    { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](https://github.com/wadakatu/laravel-spectrum/issues/${2}))" },
+]
+commit_parsers = [
+    { message = "^feat", group = "✨ Features" },
+    { message = "^fix", group = "🐛 Bug Fixes" },
+    { message = "^perf", group = "⚡ Performance Improvements" },
+    { message = "^docs", group = "📚 Documentation" },
+    { message = "^refactor", group = "♻️ Code Refactoring" },
+    { message = "^test", group = "✅ Tests" },
+    { message = "^build", group = "📦 Build System" },
+    { message = "^ci", group = "🚀 Continuous Integration" },
+    { message = "^revert", group = "⏪ Reverts" },
+]
+protect_breaking_commits = false
+filter_commits = true
+tag_pattern = "v[0-9].*"
+skip_tags = ""
+ignore_tags = ""
+sort_commits = "oldest"

--- a/.github/workflows/changelog-update.yml
+++ b/.github/workflows/changelog-update.yml
@@ -1,0 +1,34 @@
+name: Update CHANGELOG
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ssh-key: ${{ secrets.DEPLOY_KEY }}
+    
+    - name: Generate CHANGELOG
+      uses: orhun/git-cliff-action@v4
+      with:
+        config: .github/cliff.toml
+        args: --tag ${{ github.event.release.tag_name }}
+      env:
+        OUTPUT: CHANGELOG.md
+    
+    - name: Commit CHANGELOG
+      run: |
+        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git add CHANGELOG.md
+        git commit -m "docs: update CHANGELOG.md for ${{ github.event.release.tag_name }}"
+        git push origin HEAD:main


### PR DESCRIPTION
## Summary
- Replace automated Release Please workflow with manual release process
- Add git-cliff for CHANGELOG generation based on conventional commits
- Configure automatic CHANGELOG updates when releases are published

## Changes
1. **Removed Release Please files:**
   - `.github/workflows/release-please.yml`
   - `.release-please-manifest.json`
   - `release-please-config.json`

2. **Added git-cliff integration:**
   - `.github/cliff.toml` - Configuration for CHANGELOG formatting with emoji groups
   - `.github/workflows/changelog-update.yml` - Workflow to update CHANGELOG on release

## Motivation
This change provides more control over the release process while maintaining automated CHANGELOG generation. Releases will now be created manually, but the CHANGELOG will be automatically updated based on conventional commits when a release is published.

## Test plan
- [ ] Verify git-cliff configuration is valid
- [ ] Test CHANGELOG generation locally with `git cliff`
- [ ] Confirm workflow triggers correctly on release publication
- [ ] Ensure CHANGELOG format meets project standards