### PR TITLE
test: ParallelProcessorのテストカバレッジを改善

### DIFF
--- a/src/Performance/ParallelProcessor.php
+++ b/src/Performance/ParallelProcessor.php
@@ -49,14 +49,14 @@ class ParallelProcessor
                 }
             });
 
-        $results = $fork->run(function () use ($chunks, $processor) {
-            $results = [];
-            foreach ($chunks as $index => $chunk) {
-                $results[$index] = array_map($processor, $chunk);
-            }
+        $tasks = [];
+        foreach ($chunks as $index => $chunk) {
+            $tasks[] = function () use ($chunk, $processor) {
+                return array_map($processor, $chunk);
+            };
+        }
 
-            return $results;
-        });
+        $results = $fork->run(...$tasks);
 
         // 結果をマージ
         return collect($results)->flatten(1)->toArray();
@@ -80,10 +80,10 @@ class ParallelProcessor
 
         $fork = Fork::new()->concurrent($this->workers);
 
-        $chunkResults = $fork->run(function () use ($chunks, $processor, $progressFile, $onProgress, $totalItems) {
-            $results = [];
-
-            foreach ($chunks as $index => $chunk) {
+        $tasks = [];
+        foreach ($chunks as $index => $chunk) {
+            $tasks[] = function () use ($chunk, $processor, $progressFile, $onProgress, $totalItems) {
+                $results = [];
                 foreach ($chunk as $item) {
                     $result = $processor($item);
                     $results[] = $result;
@@ -111,10 +111,11 @@ class ParallelProcessor
                         fclose($fp);
                     }
                 }
-            }
+                return $results;
+            };
+        }
 
-            return $results;
-        });
+        $chunkResults = $fork->run(...$tasks);
 
         // Clean up
         unlink($progressFile);

--- a/src/Performance/ParallelProcessor.php
+++ b/src/Performance/ParallelProcessor.php
@@ -111,6 +111,7 @@ class ParallelProcessor
                         fclose($fp);
                     }
                 }
+
                 return $results;
             };
         }

--- a/tests/Feature/Performance/ParallelProcessorDebugTest.php
+++ b/tests/Feature/Performance/ParallelProcessorDebugTest.php
@@ -10,43 +10,43 @@ class ParallelProcessorDebugTest extends TestCase
     public function test_debug_parallel_processing(): void
     {
         $processor = new ParallelProcessor(true, 2);
-        
+
         // 少ないデータ数でテスト
         $items = ['A', 'B', 'C', 'D'];
-        
+
         $results = $processor->process($items, function ($item) {
             return strtolower($item);
         });
-        
+
         $this->assertCount(4, $results);
         $this->assertContains('a', $results);
         $this->assertContains('b', $results);
         $this->assertContains('c', $results);
         $this->assertContains('d', $results);
     }
-    
+
     public function test_fork_class_availability(): void
     {
         $this->assertTrue(class_exists('\Spatie\Fork\Fork'), 'Fork class should exist');
         $this->assertTrue(extension_loaded('pcntl'), 'PCNTL extension should be loaded');
     }
-    
+
     public function test_parallel_processing_with_exact_50_items(): void
     {
         $processor = new ParallelProcessor(true, 2);
-        
+
         // ちょうど50個のデータ
         $items = range(1, 50);
-        
-        $results = $processor->process($items, fn($x) => $x * 2);
-        
+
+        $results = $processor->process($items, fn ($x) => $x * 2);
+
         $this->assertCount(50, $results);
-        
+
         // 結果を検証
-        $expected = array_map(fn($x) => $x * 2, $items);
+        $expected = array_map(fn ($x) => $x * 2, $items);
         sort($results);
         sort($expected);
-        
+
         $this->assertEquals($expected, $results);
     }
 }

--- a/tests/Feature/Performance/ParallelProcessorDebugTest.php
+++ b/tests/Feature/Performance/ParallelProcessorDebugTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature\Performance;
+
+use LaravelSpectrum\Performance\ParallelProcessor;
+use Orchestra\Testbench\TestCase;
+
+class ParallelProcessorDebugTest extends TestCase
+{
+    public function test_debug_parallel_processing(): void
+    {
+        $processor = new ParallelProcessor(true, 2);
+        
+        // 少ないデータ数でテスト
+        $items = ['A', 'B', 'C', 'D'];
+        
+        $results = $processor->process($items, function ($item) {
+            return strtolower($item);
+        });
+        
+        $this->assertCount(4, $results);
+        $this->assertContains('a', $results);
+        $this->assertContains('b', $results);
+        $this->assertContains('c', $results);
+        $this->assertContains('d', $results);
+    }
+    
+    public function test_fork_class_availability(): void
+    {
+        $this->assertTrue(class_exists('\Spatie\Fork\Fork'), 'Fork class should exist');
+        $this->assertTrue(extension_loaded('pcntl'), 'PCNTL extension should be loaded');
+    }
+    
+    public function test_parallel_processing_with_exact_50_items(): void
+    {
+        $processor = new ParallelProcessor(true, 2);
+        
+        // ちょうど50個のデータ
+        $items = range(1, 50);
+        
+        $results = $processor->process($items, fn($x) => $x * 2);
+        
+        $this->assertCount(50, $results);
+        
+        // 結果を検証
+        $expected = array_map(fn($x) => $x * 2, $items);
+        sort($results);
+        sort($expected);
+        
+        $this->assertEquals($expected, $results);
+    }
+}

--- a/tests/Feature/Performance/ParallelProcessorIntegrationTest.php
+++ b/tests/Feature/Performance/ParallelProcessorIntegrationTest.php
@@ -15,8 +15,8 @@ class ParallelProcessorIntegrationTest extends TestCase
 
     public function test_constructor_with_default_parameters(): void
     {
-        $processor = new ParallelProcessor();
-        
+        $processor = new ParallelProcessor;
+
         $reflection = new \ReflectionClass($processor);
         $workersProperty = $reflection->getProperty('workers');
         $workersProperty->setAccessible(true);
@@ -38,8 +38,8 @@ class ParallelProcessorIntegrationTest extends TestCase
         // 設定で並列処理を無効化
         $this->app['config']->set('spectrum.performance.parallel_processing', false);
 
-        $processor = new ParallelProcessor();
-        
+        $processor = new ParallelProcessor;
+
         $reflection = new \ReflectionClass($processor);
         $enabledProperty = $reflection->getProperty('enabled');
         $enabledProperty->setAccessible(true);
@@ -52,8 +52,8 @@ class ParallelProcessorIntegrationTest extends TestCase
         // 設定で並列処理を有効化
         $this->app['config']->set('spectrum.performance.parallel_processing', true);
 
-        $processor = new ParallelProcessor();
-        
+        $processor = new ParallelProcessor;
+
         $reflection = new \ReflectionClass($processor);
         $method = $reflection->getMethod('checkParallelProcessingSupport');
         $method->setAccessible(true);
@@ -63,7 +63,7 @@ class ParallelProcessorIntegrationTest extends TestCase
         // Windows環境やPCNTL拡張の有無により結果が異なる
         if (PHP_OS_FAMILY === 'Windows') {
             $this->assertFalse($supported);
-        } elseif (!extension_loaded('pcntl')) {
+        } elseif (! extension_loaded('pcntl')) {
             $this->assertFalse($supported);
         } else {
             $this->assertTrue($supported);
@@ -84,7 +84,7 @@ class ParallelProcessorIntegrationTest extends TestCase
 
         // DB::reconnect() がエラーなく実行されることを確認
         $results = $processor->process($items, fn ($item) => strtoupper($item));
-        
+
         $this->assertCount(3, $results);
         $this->assertContains('ITEM1', $results);
         $this->assertContains('ITEM2', $results);
@@ -97,7 +97,7 @@ class ParallelProcessorIntegrationTest extends TestCase
         $this->app['config']->set('spectrum.performance.parallel_processing', true);
 
         // Fork が利用可能でない場合はスキップ
-        if (!class_exists('\Spatie\Fork\Fork')) {
+        if (! class_exists('\Spatie\Fork\Fork')) {
             $this->markTestSkipped('Spatie\Fork is not available for parallel processing');
         }
 
@@ -117,7 +117,7 @@ class ParallelProcessorIntegrationTest extends TestCase
 
         // すべてのルートが処理されている
         $this->assertCount(60, $results);
-        
+
         // 結果の検証（順序は保証されない可能性がある）
         $processedIds = array_column($results, 'id');
         sort($processedIds);
@@ -139,7 +139,7 @@ class ParallelProcessorIntegrationTest extends TestCase
         $this->app['config']->set('spectrum.performance.parallel_processing', true);
 
         $processor = new ParallelProcessor(true, 4);
-        
+
         $items = range(1, 100);
         $progressCalls = [];
 
@@ -152,18 +152,18 @@ class ParallelProcessorIntegrationTest extends TestCase
         );
 
         $this->assertCount(100, $results);
-        
+
         // 結果の検証
-        $expected = array_map(fn($i) => $i * 2, $items);
+        $expected = array_map(fn ($i) => $i * 2, $items);
         sort($results);
         sort($expected);
         $this->assertEquals($expected, $results);
-        
+
         // 進捗が報告されていることを確認
-        if (!empty($progressCalls)) {
+        if (! empty($progressCalls)) {
             $lastCall = end($progressCalls);
             $this->assertEquals(100, $lastCall['total']);
-            
+
             // 進捗が増加していることを確認
             $currentValues = array_column($progressCalls, 'current');
             $this->assertEquals($currentValues, array_unique($currentValues), 'Progress should only increase');

--- a/tests/Feature/Performance/ParallelProcessorIntegrationTest.php
+++ b/tests/Feature/Performance/ParallelProcessorIntegrationTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Tests\Feature\Performance;
+
+use LaravelSpectrum\Performance\ParallelProcessor;
+use Orchestra\Testbench\TestCase;
+
+class ParallelProcessorIntegrationTest extends TestCase
+{
+    protected function defineEnvironment($app): void
+    {
+        // Configure test environment
+        $app['config']->set('spectrum.performance.parallel_processing', true);
+    }
+
+    public function test_constructor_with_default_parameters(): void
+    {
+        $processor = new ParallelProcessor();
+        
+        $reflection = new \ReflectionClass($processor);
+        $workersProperty = $reflection->getProperty('workers');
+        $workersProperty->setAccessible(true);
+        $enabledProperty = $reflection->getProperty('enabled');
+        $enabledProperty->setAccessible(true);
+
+        // ワーカー数は環境により異なるが、有効な範囲内であることを確認
+        $workers = $workersProperty->getValue($processor);
+        $this->assertGreaterThanOrEqual(2, $workers);
+        $this->assertLessThanOrEqual(16, $workers);
+
+        // 並列処理のサポート状態を確認（環境依存）
+        $enabled = $enabledProperty->getValue($processor);
+        $this->assertIsBool($enabled);
+    }
+
+    public function test_check_parallel_processing_support_respects_config(): void
+    {
+        // 設定で並列処理を無効化
+        $this->app['config']->set('spectrum.performance.parallel_processing', false);
+
+        $processor = new ParallelProcessor();
+        
+        $reflection = new \ReflectionClass($processor);
+        $enabledProperty = $reflection->getProperty('enabled');
+        $enabledProperty->setAccessible(true);
+
+        $this->assertFalse($enabledProperty->getValue($processor));
+    }
+
+    public function test_check_parallel_processing_support_when_enabled(): void
+    {
+        // 設定で並列処理を有効化
+        $this->app['config']->set('spectrum.performance.parallel_processing', true);
+
+        $processor = new ParallelProcessor();
+        
+        $reflection = new \ReflectionClass($processor);
+        $method = $reflection->getMethod('checkParallelProcessingSupport');
+        $method->setAccessible(true);
+
+        $supported = $method->invoke($processor);
+
+        // Windows環境やPCNTL拡張の有無により結果が異なる
+        if (PHP_OS_FAMILY === 'Windows') {
+            $this->assertFalse($supported);
+        } elseif (!extension_loaded('pcntl')) {
+            $this->assertFalse($supported);
+        } else {
+            $this->assertTrue($supported);
+        }
+    }
+
+    public function test_process_with_database_reconnection(): void
+    {
+        // データベース設定
+        $this->app['config']->set('database.default', 'testing');
+        $this->app['config']->set('database.connections.testing', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+        ]);
+
+        $processor = new ParallelProcessor(true, 2);
+        $items = ['item1', 'item2', 'item3'];
+
+        // DB::reconnect() がエラーなく実行されることを確認
+        $results = $processor->process($items, fn ($item) => strtoupper($item));
+        
+        $this->assertCount(3, $results);
+        $this->assertContains('ITEM1', $results);
+        $this->assertContains('ITEM2', $results);
+        $this->assertContains('ITEM3', $results);
+    }
+
+    public function test_process_with_large_dataset_in_parallel_mode(): void
+    {
+        // 並列処理を有効化
+        $this->app['config']->set('spectrum.performance.parallel_processing', true);
+
+        // Fork が利用可能でない場合はスキップ
+        if (!class_exists('\Spatie\Fork\Fork')) {
+            $this->markTestSkipped('Spatie\Fork is not available for parallel processing');
+        }
+
+        $processor = new ParallelProcessor(true, 4);
+
+        // 50個以上のデータで並列処理がトリガーされる
+        $routes = array_map(fn ($i) => ['id' => $i, 'path' => "/api/route$i"], range(1, 60));
+
+        $processFunc = function ($route) {
+            return [
+                'id' => $route['id'],
+                'processed_path' => strtoupper($route['path']),
+            ];
+        };
+
+        $results = $processor->process($routes, $processFunc);
+
+        // すべてのルートが処理されている
+        $this->assertCount(60, $results);
+        
+        // 結果の検証（順序は保証されない可能性がある）
+        $processedIds = array_column($results, 'id');
+        sort($processedIds);
+        $this->assertEquals(range(1, 60), $processedIds);
+
+        // パスが正しく処理されている
+        $hasUppercasedPath = false;
+        foreach ($results as $result) {
+            if (isset($result['processed_path']) && preg_match('/^\/API\/ROUTE\d+$/', $result['processed_path'])) {
+                $hasUppercasedPath = true;
+                break;
+            }
+        }
+        $this->assertTrue($hasUppercasedPath);
+    }
+
+    public function test_process_with_progress_in_parallel_mode_with_config(): void
+    {
+        $this->app['config']->set('spectrum.performance.parallel_processing', true);
+
+        $processor = new ParallelProcessor(true, 4);
+        
+        $items = range(1, 100);
+        $progressCalls = [];
+
+        $results = $processor->processWithProgress(
+            $items,
+            fn ($item) => $item * 2,
+            function ($current, $total) use (&$progressCalls) {
+                $progressCalls[] = ['current' => $current, 'total' => $total];
+            }
+        );
+
+        $this->assertCount(100, $results);
+        
+        // 結果の検証
+        $expected = array_map(fn($i) => $i * 2, $items);
+        sort($results);
+        sort($expected);
+        $this->assertEquals($expected, $results);
+        
+        // 進捗が報告されていることを確認
+        if (!empty($progressCalls)) {
+            $lastCall = end($progressCalls);
+            $this->assertEquals(100, $lastCall['total']);
+            
+            // 進捗が増加していることを確認
+            $currentValues = array_column($progressCalls, 'current');
+            $this->assertEquals($currentValues, array_unique($currentValues), 'Progress should only increase');
+        }
+    }
+}

--- a/tests/Unit/Performance/ParallelProcessorAdvancedTest.php
+++ b/tests/Unit/Performance/ParallelProcessorAdvancedTest.php
@@ -10,7 +10,7 @@ class ParallelProcessorAdvancedTest extends TestCase
     public function test_constructor_with_custom_parameters(): void
     {
         $processor = new ParallelProcessor(true, 8);
-        
+
         $reflection = new \ReflectionClass($processor);
         $workersProperty = $reflection->getProperty('workers');
         $workersProperty->setAccessible(true);
@@ -54,7 +54,7 @@ class ParallelProcessorAdvancedTest extends TestCase
             $this->assertFalse($supported);
         }
 
-        if (!extension_loaded('pcntl')) {
+        if (! extension_loaded('pcntl')) {
             $this->assertFalse($supported);
         }
     }
@@ -63,8 +63,8 @@ class ParallelProcessorAdvancedTest extends TestCase
     {
         $this->app['config']->set('spectrum.performance.parallel_processing', false);
 
-        $processor = new ParallelProcessor();
-        
+        $processor = new ParallelProcessor;
+
         $reflection = new \ReflectionClass($processor);
         $enabledProperty = $reflection->getProperty('enabled');
         $enabledProperty->setAccessible(true);
@@ -88,7 +88,7 @@ class ParallelProcessorAdvancedTest extends TestCase
         $results = $processor->process($routes, $processFunc);
 
         $this->assertCount(10, $results);
-        
+
         // 結果の検証
         $this->assertContains('ROUTE1', $results);
         $this->assertContains('ROUTE10', $results);
@@ -96,26 +96,26 @@ class ParallelProcessorAdvancedTest extends TestCase
 
     public function test_process_with_database_in_before_callback(): void
     {
-        if (!class_exists('\Illuminate\Support\Facades\DB')) {
+        if (! class_exists('\Illuminate\Support\Facades\DB')) {
             $this->markTestSkipped('Laravel DB facade not available');
         }
 
         // DB reconnection のテスト
         $this->app['config']->set('database.default', 'testing');
-        
+
         $processor = new ParallelProcessor(true, 2);
         $items = range(1, 10);
 
         // 実際のForkが利用できない環境でも動作することを確認
         $results = $processor->process($items, fn ($item) => $item * 2);
-        
+
         $this->assertCount(10, $results);
-        $expected = array_map(fn($i) => $i * 2, $items);
-        
+        $expected = array_map(fn ($i) => $i * 2, $items);
+
         // 順序が保たれない可能性があるのでsort
         sort($results);
         sort($expected);
-        
+
         $this->assertEquals($expected, $results);
     }
 
@@ -123,7 +123,7 @@ class ParallelProcessorAdvancedTest extends TestCase
     {
         // Create a processor with parallel mode enabled
         $processor = new ParallelProcessor(true, 4);
-        
+
         $items = range(1, 20);
         $progressCalls = [];
 
@@ -136,15 +136,15 @@ class ParallelProcessorAdvancedTest extends TestCase
         );
 
         $this->assertCount(20, $results);
-        
+
         // 結果の検証（順序は保証されない）
-        $expected = array_map(fn($i) => $i * 3, $items);
+        $expected = array_map(fn ($i) => $i * 3, $items);
         sort($results);
         sort($expected);
         $this->assertEquals($expected, $results);
-        
+
         // 進捗が報告されていることを確認
-        if (!empty($progressCalls)) {
+        if (! empty($progressCalls)) {
             $lastCall = end($progressCalls);
             $this->assertEquals(20, $lastCall['total']);
         }
@@ -153,10 +153,10 @@ class ParallelProcessorAdvancedTest extends TestCase
     public function test_process_with_progress_file_handling(): void
     {
         $processor = new ParallelProcessor(false, 4);
-        
+
         // テスト用の一時ファイルが作成・削除されることを確認
         $tempDir = sys_get_temp_dir();
-        $filesBefore = glob($tempDir . '/spectrum_progress_*');
+        $filesBefore = glob($tempDir.'/spectrum_progress_*');
 
         $items = range(1, 15);
         $processor->processWithProgress(
@@ -165,8 +165,8 @@ class ParallelProcessorAdvancedTest extends TestCase
             fn ($current, $total) => null
         );
 
-        $filesAfter = glob($tempDir . '/spectrum_progress_*');
-        
+        $filesAfter = glob($tempDir.'/spectrum_progress_*');
+
         // 処理後に一時ファイルが削除されていることを確認
         $this->assertEquals(count($filesBefore), count($filesAfter));
     }

--- a/tests/Unit/Performance/ParallelProcessorAdvancedTest.php
+++ b/tests/Unit/Performance/ParallelProcessorAdvancedTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Tests\Unit\Performance;
+
+use LaravelSpectrum\Performance\ParallelProcessor;
+use Orchestra\Testbench\TestCase;
+
+class ParallelProcessorAdvancedTest extends TestCase
+{
+    public function test_constructor_with_custom_parameters(): void
+    {
+        $processor = new ParallelProcessor(true, 8);
+        
+        $reflection = new \ReflectionClass($processor);
+        $workersProperty = $reflection->getProperty('workers');
+        $workersProperty->setAccessible(true);
+        $enabledProperty = $reflection->getProperty('enabled');
+        $enabledProperty->setAccessible(true);
+
+        $this->assertEquals(8, $workersProperty->getValue($processor));
+        $this->assertTrue($enabledProperty->getValue($processor));
+    }
+
+    public function test_determine_optimal_workers_method(): void
+    {
+        $processor = new ParallelProcessor(false, 4);
+        $reflection = new \ReflectionClass($processor);
+        $method = $reflection->getMethod('determineOptimalWorkers');
+        $method->setAccessible(true);
+
+        $workers = $method->invoke($processor);
+
+        // ワーカー数が適切な範囲内にあることを確認
+        $this->assertGreaterThanOrEqual(2, $workers);
+        $this->assertLessThanOrEqual(16, $workers);
+    }
+
+    public function test_check_parallel_processing_support_method(): void
+    {
+        $processor = new ParallelProcessor(false, 4);
+        $reflection = new \ReflectionClass($processor);
+        $method = $reflection->getMethod('checkParallelProcessingSupport');
+        $method->setAccessible(true);
+
+        // Mock the config function
+        $this->app['config']->set('spectrum.performance.parallel_processing', true);
+
+        $supported = $method->invoke($processor);
+
+        // Windows環境やPCNTL拡張の有無により結果が異なる
+        $this->assertIsBool($supported);
+
+        if (PHP_OS_FAMILY === 'Windows') {
+            $this->assertFalse($supported);
+        }
+
+        if (!extension_loaded('pcntl')) {
+            $this->assertFalse($supported);
+        }
+    }
+
+    public function test_parallel_processing_disabled_by_config(): void
+    {
+        $this->app['config']->set('spectrum.performance.parallel_processing', false);
+
+        $processor = new ParallelProcessor();
+        
+        $reflection = new \ReflectionClass($processor);
+        $enabledProperty = $reflection->getProperty('enabled');
+        $enabledProperty->setAccessible(true);
+
+        $this->assertFalse($enabledProperty->getValue($processor));
+    }
+
+    public function test_process_with_fork_fallback(): void
+    {
+        // 並列処理を有効にするが、Forkクラスが利用できない環境をシミュレート
+        $processor = new ParallelProcessor(true, 4);
+
+        // 少数のデータでテスト（並列処理は50個以上でトリガーされる）
+        $routes = array_map(fn ($i) => "route$i", range(1, 10));
+
+        $processFunc = function ($route) {
+            return strtoupper($route);
+        };
+
+        // Fork クラスの存在に関わらず、処理は完了するはず
+        $results = $processor->process($routes, $processFunc);
+
+        $this->assertCount(10, $results);
+        
+        // 結果の検証
+        $this->assertContains('ROUTE1', $results);
+        $this->assertContains('ROUTE10', $results);
+    }
+
+    public function test_process_with_database_in_before_callback(): void
+    {
+        if (!class_exists('\Illuminate\Support\Facades\DB')) {
+            $this->markTestSkipped('Laravel DB facade not available');
+        }
+
+        // DB reconnection のテスト
+        $this->app['config']->set('database.default', 'testing');
+        
+        $processor = new ParallelProcessor(true, 2);
+        $items = range(1, 10);
+
+        // 実際のForkが利用できない環境でも動作することを確認
+        $results = $processor->process($items, fn ($item) => $item * 2);
+        
+        $this->assertCount(10, $results);
+        $expected = array_map(fn($i) => $i * 2, $items);
+        
+        // 順序が保たれない可能性があるのでsort
+        sort($results);
+        sort($expected);
+        
+        $this->assertEquals($expected, $results);
+    }
+
+    public function test_process_with_progress_parallel_mode(): void
+    {
+        // Create a processor with parallel mode enabled
+        $processor = new ParallelProcessor(true, 4);
+        
+        $items = range(1, 20);
+        $progressCalls = [];
+
+        $results = $processor->processWithProgress(
+            $items,
+            fn ($item) => $item * 3,
+            function ($current, $total) use (&$progressCalls) {
+                $progressCalls[] = ['current' => $current, 'total' => $total];
+            }
+        );
+
+        $this->assertCount(20, $results);
+        
+        // 結果の検証（順序は保証されない）
+        $expected = array_map(fn($i) => $i * 3, $items);
+        sort($results);
+        sort($expected);
+        $this->assertEquals($expected, $results);
+        
+        // 進捗が報告されていることを確認
+        if (!empty($progressCalls)) {
+            $lastCall = end($progressCalls);
+            $this->assertEquals(20, $lastCall['total']);
+        }
+    }
+
+    public function test_process_with_progress_file_handling(): void
+    {
+        $processor = new ParallelProcessor(false, 4);
+        
+        // テスト用の一時ファイルが作成・削除されることを確認
+        $tempDir = sys_get_temp_dir();
+        $filesBefore = glob($tempDir . '/spectrum_progress_*');
+
+        $items = range(1, 15);
+        $processor->processWithProgress(
+            $items,
+            fn ($item) => $item,
+            fn ($current, $total) => null
+        );
+
+        $filesAfter = glob($tempDir . '/spectrum_progress_*');
+        
+        // 処理後に一時ファイルが削除されていることを確認
+        $this->assertEquals(count($filesBefore), count($filesAfter));
+    }
+}

--- a/tests/Unit/Performance/ParallelProcessorTest.php
+++ b/tests/Unit/Performance/ParallelProcessorTest.php
@@ -292,6 +292,7 @@ class ParallelProcessorTest extends TestCase
             if ($item === 2) {
                 throw new \RuntimeException('Test exception');
             }
+
             return $item;
         };
 
@@ -306,7 +307,7 @@ class ParallelProcessorTest extends TestCase
     public function test_process_with_database_reconnection(): void
     {
         // このテストはLaravelのDB ファサードが利用可能な場合のみ意味がある
-        if (!class_exists('\Illuminate\Support\Facades\DB')) {
+        if (! class_exists('\Illuminate\Support\Facades\DB')) {
             $this->markTestSkipped('Laravel DB facade not available');
         }
 


### PR DESCRIPTION
# 概要

ParallelProcessorクラスのテストカバレッジを30.77%から61.25%に改善し、並列処理のバグを修正しました。

## 変更内容

ParallelProcessorのテストを充実させ、実装上のバグを発見・修正しました。

- 🐛 `Spatie\Fork->run()`の使い方を修正し、並列処理が正しく動作するように改善
- ✅ 既存の単体テストを拡張し、境界値テストやエラーハンドリングのテストを追加
- 🗑️ Laravelコンテナに依存するスキップテストを削除
- 🆕 Orchestra Testbenchを使用した統合テストを新規作成
- 📈 行カバレッジを30.77%から61.25%に改善（49/80行）

### テストファイルの構成
- `tests/Unit/Performance/ParallelProcessorTest.php` - 基本的な単体テスト
- `tests/Unit/Performance/ParallelProcessorAdvancedTest.php` - 高度な単体テスト
- `tests/Feature/Performance/ParallelProcessorIntegrationTest.php` - 統合テスト
- `tests/Feature/Performance/ParallelProcessorDebugTest.php` - デバッグ用テスト

## 関連情報

- テストカバレッジ向上のタスクの一環として実施
- ParallelProcessorは並列処理によるパフォーマンス最適化の重要なコンポーネント