### PR TITLE
Bugfix: CHANGELOGワークフローのプッシュ競合を修正

### DIFF
--- a/.github/workflows/changelog-update.yml
+++ b/.github/workflows/changelog-update.yml
@@ -29,6 +29,7 @@ jobs:
       run: |
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
+        git pull origin main --rebase
         git add CHANGELOG.md
         git commit -m "docs: update CHANGELOG.md for ${{ github.event.release.tag_name }}"
         git push origin HEAD:main


### PR DESCRIPTION
# 概要

CHANGELOGの自動更新ワークフローでプッシュ時に発生する競合エラーを修正しました。

## 変更内容

複数のリリースが短時間で実行された際に発生するプッシュエラーを防ぐための修正を実施しました。

- `.github/workflows/changelog-update.yml`に`git pull origin main --rebase`を追加
- プッシュ前にリモートの最新変更を取得してリベースすることで競合を回避
- これにより、連続したリリース時でもCHANGELOGが正常に更新されるようになります

## 関連情報

ローカルテスト実行時に以下のエラーが発生していたことを確認：
```
error: failed to push some refs to 'github.com:wadakatu/laravel-spectrum.git'
hint: Updates were rejected because the remote contains work that you do not have locally.
```