### PR TITLE
Refactoring: Drop Laravel 10 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.1, 8.2, 8.3, 8.4]
-        laravel: [10.*, 11.*, 12.*]
+        laravel: [11.*, 12.*]
         include:
-          - laravel: 10.*
-            testbench: 8.*
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*

--- a/composer.json
+++ b/composer.json
@@ -28,16 +28,16 @@
     },
     "require": {
         "php": "^8.1",
-        "illuminate/console": "^10.0|^11.0|^12.0",
-        "illuminate/routing": "^10.0|^11.0|^12.0",
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/console": "^11.0|^12.0",
+        "illuminate/routing": "^11.0|^12.0",
+        "illuminate/support": "^11.0|^12.0",
         "nikic/php-parser": "^5.5",
         "spatie/fork": "^1.2",
         "symfony/finder": "^6.0|^7.0",
         "workerman/workerman": "^5.1"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^9.0|^10.0",
         "phpunit/phpunit": "^10.0|^11.0|^12.0",
         "laravel/pint": "^1.23",
         "phpstan/phpstan": "^2.1",


### PR DESCRIPTION
# 概要

Laravel 10のサポートを終了し、Laravel 11以降のみをサポートするようにリファクタリングしました。

## 変更内容

Laravel 10は2025年2月でセキュリティサポートが終了するため、プロジェクトから削除しました。

- composer.jsonからLaravel 10の依存関係を削除
- GitHub ActionsのテストマトリックスからLaravel 10を削除
- orchestra/testbench 8.xの設定を削除
- ドキュメントのサポートバージョンを更新

## 関連情報

このPRは破壊的変更を含みます。次のメジャーバージョンリリースに含める必要があります。

- **最小サポートバージョン**: Laravel 11.x
- **影響**: Laravel 10を使用しているユーザーはアップグレードが必要