### PR TITLE
Bugfix: PHP 8.1サポートを削除

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,20 +12,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
+        php: [8.2, 8.3, 8.4]
         laravel: [11.*, 12.*]
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
-        exclude:
-          # Laravel 11 requires PHP 8.2+
-          - php: 8.1
-            laravel: 11.*
-          # Laravel 12 requires PHP 8.2+
-          - php: 8.1
-            laravel: 12.*
+
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}
 
@@ -48,9 +42,6 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          if [[ "${{ matrix.php }}" == "8.1" ]]; then
-            composer remove laravel/pint phpstan/phpstan --dev --no-update
-          fi
           composer update --prefer-stable --prefer-dist --no-interaction
 
       - name: List Installed Dependencies


### PR DESCRIPTION
# 概要

Laravel 11はPHP 8.2以上を要求するため、GitHub ActionsのテストマトリックスからPHP 8.1を削除しました。

## 変更内容

GitHub Actionsワークフローを更新し、不要になったPHP 8.1関連の設定を削除しました。

- テストマトリックスからPHP 8.1を削除（8.2, 8.3, 8.4のみテスト）
- PHP 8.1用のexclude設定を削除
- Install dependenciesステップからPHP 8.1用の条件分岐を削除

## 関連情報

- Laravel 11の動作要件に準拠した修正