### PR TITLE
Bugfix: GitHub ActionsのCHANGELOG更新ワークフローでunstaged changesエラーを修正

### DIFF
--- a/.github/workflows/changelog-update.yml
+++ b/.github/workflows/changelog-update.yml
@@ -29,7 +29,9 @@ jobs:
       run: |
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
+        git stash
         git pull origin main --rebase
+        git stash pop || true
         git add CHANGELOG.md
         git commit -m "docs: update CHANGELOG.md for ${{ github.event.release.tag_name }}"
         git push origin HEAD:main


### PR DESCRIPTION
# 概要

GitHub ActionsのCHANGELOG更新ワークフローで、unstaged changesがある場合にrebaseが失敗する問題を修正しました。

## 変更内容

ワークフローのrebase処理を改善し、エラーを防ぐようにしました。

- `git stash`でunstaged changesを一時退避
- `git pull --rebase`を実行
- `git stash pop`で退避した変更を復元（失敗しても続行）

この修正により、CHANGELOG生成時に予期しない変更があってもワークフローが正常に動作するようになります。

## 関連情報

- ワークフロー実行時のエラー: `error: cannot pull with rebase: You have unstaged changes.`